### PR TITLE
Change prefix for attribute

### DIFF
--- a/Input.js
+++ b/Input.js
@@ -166,7 +166,7 @@ export class Attribute extends BaseParams {
         this.ptype = ParamType.ATTRIBUTE;
         this.name = name;
         this.size = size;
-        this.token = `v_${this.name}`;
+        this.token = `va${this.name}`;
     }
     _genCode(slots) { }
     genInputCode(slots, input) {

--- a/docs/data.json
+++ b/docs/data.json
@@ -34,7 +34,7 @@
 							"fileName": "src/AlphaModeEnum.ts",
 							"line": 17,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/AlphaModeEnum.ts#L17"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/AlphaModeEnum.ts#L17"
 						}
 					],
 					"type": {
@@ -74,7 +74,7 @@
 							"fileName": "src/AlphaModeEnum.ts",
 							"line": 4,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/AlphaModeEnum.ts#L4"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/AlphaModeEnum.ts#L4"
 						}
 					],
 					"type": {
@@ -120,7 +120,7 @@
 					"fileName": "src/AlphaModeEnum.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/AlphaModeEnum.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/AlphaModeEnum.ts#L1"
 				}
 			]
 		},
@@ -199,7 +199,7 @@
 									"fileName": "src/Bounds.ts",
 									"line": 16,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Bounds.ts#L16"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Bounds.ts#L16"
 								}
 							],
 							"type": {
@@ -242,7 +242,7 @@
 									"fileName": "src/Bounds.ts",
 									"line": 21,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Bounds.ts#L21"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Bounds.ts#L21"
 								}
 							],
 							"type": {
@@ -266,7 +266,7 @@
 									"fileName": "src/Bounds.ts",
 									"line": 29,
 									"character": 9,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Bounds.ts#L29"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Bounds.ts#L29"
 								}
 							],
 							"signatures": [
@@ -360,7 +360,7 @@
 							"fileName": "src/Bounds.ts",
 							"line": 11,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Bounds.ts#L11"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Bounds.ts#L11"
 						}
 					]
 				},
@@ -391,7 +391,7 @@
 									"fileName": "src/Bounds.ts",
 									"line": 55,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Bounds.ts#L55"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Bounds.ts#L55"
 								}
 							],
 							"signatures": [
@@ -430,7 +430,7 @@
 									"fileName": "src/Bounds.ts",
 									"line": 48,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Bounds.ts#L48"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Bounds.ts#L48"
 								}
 							],
 							"type": {
@@ -462,7 +462,7 @@
 									"fileName": "src/Bounds.ts",
 									"line": 53,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Bounds.ts#L53"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Bounds.ts#L53"
 								}
 							],
 							"type": {
@@ -493,7 +493,7 @@
 									"fileName": "src/Bounds.ts",
 									"line": 51,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Bounds.ts#L51"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Bounds.ts#L51"
 								}
 							],
 							"type": {
@@ -514,7 +514,7 @@
 									"fileName": "src/Bounds.ts",
 									"line": 73,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Bounds.ts#L73"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Bounds.ts#L73"
 								}
 							],
 							"signatures": [
@@ -572,7 +572,7 @@
 									"fileName": "src/Bounds.ts",
 									"line": 83,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Bounds.ts#L83"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Bounds.ts#L83"
 								}
 							],
 							"signatures": [
@@ -676,7 +676,7 @@
 									"fileName": "src/Bounds.ts",
 									"line": 64,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Bounds.ts#L64"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Bounds.ts#L64"
 								}
 							],
 							"signatures": [
@@ -714,7 +714,7 @@
 									"fileName": "src/Bounds.ts",
 									"line": 109,
 									"character": 9,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Bounds.ts#L109"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Bounds.ts#L109"
 								}
 							],
 							"signatures": [
@@ -815,7 +815,7 @@
 									"fileName": "src/Bounds.ts",
 									"line": 94,
 									"character": 9,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Bounds.ts#L94"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Bounds.ts#L94"
 								}
 							],
 							"signatures": [
@@ -934,7 +934,7 @@
 							"fileName": "src/Bounds.ts",
 							"line": 46,
 							"character": 21,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Bounds.ts#L46"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Bounds.ts#L46"
 						}
 					]
 				}
@@ -953,7 +953,7 @@
 					"fileName": "src/Bounds.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Bounds.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Bounds.ts#L1"
 				}
 			]
 		},
@@ -993,7 +993,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 39,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L39"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L39"
 								}
 							],
 							"signatures": [
@@ -1078,7 +1078,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -1111,7 +1111,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -1140,7 +1140,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -1169,7 +1169,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -1198,7 +1198,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 14,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L14"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L14"
 								}
 							],
 							"type": {
@@ -1236,7 +1236,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -1265,7 +1265,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -1299,7 +1299,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -1333,7 +1333,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -1370,7 +1370,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 166,
 									"character": 21,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L166"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L166"
 								}
 							],
 							"signatures": [
@@ -1438,7 +1438,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -1526,7 +1526,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -1584,7 +1584,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -1678,7 +1678,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -1715,7 +1715,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -1773,7 +1773,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -1831,7 +1831,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -1867,7 +1867,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -1903,7 +1903,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -1971,7 +1971,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -2029,7 +2029,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -2087,7 +2087,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 172,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L172"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L172"
 								}
 							],
 							"signatures": [
@@ -2186,7 +2186,7 @@
 							"fileName": "src/Chunk.ts",
 							"line": 12,
 							"character": 30,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L12"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L12"
 						}
 					],
 					"extendedBy": [
@@ -2276,7 +2276,7 @@
 					"fileName": "src/Chunk.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L1"
 				}
 			]
 		},
@@ -2343,7 +2343,7 @@
 									"fileName": "src/ChunkCollection.ts",
 									"line": 27,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L27"
 								}
 							],
 							"type": {
@@ -2380,7 +2380,7 @@
 									"fileName": "src/ChunkCollection.ts",
 									"line": 22,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L22"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L22"
 								}
 							],
 							"type": {
@@ -2417,7 +2417,7 @@
 									"fileName": "src/ChunkCollection.ts",
 									"line": 40,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L40"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L40"
 								}
 							],
 							"type": {
@@ -2455,7 +2455,7 @@
 									"fileName": "src/ChunkCollection.ts",
 									"line": 29,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L29"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L29"
 								}
 							],
 							"type": {
@@ -2487,7 +2487,7 @@
 									"fileName": "src/ChunkCollection.ts",
 									"line": 33,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L33"
 								}
 							],
 							"type": {
@@ -2521,7 +2521,7 @@
 									"fileName": "src/ChunkCollection.ts",
 									"line": 15,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L15"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L15"
 								}
 							],
 							"type": {
@@ -2551,7 +2551,7 @@
 									"fileName": "src/ChunkCollection.ts",
 									"line": 13,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L13"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L13"
 								}
 							],
 							"type": {
@@ -2581,7 +2581,7 @@
 									"fileName": "src/ChunkCollection.ts",
 									"line": 17,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L17"
 								}
 							],
 							"type": {
@@ -2609,7 +2609,7 @@
 									"fileName": "src/ChunkCollection.ts",
 									"line": 31,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L31"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L31"
 								}
 							],
 							"type": {
@@ -2633,7 +2633,7 @@
 									"fileName": "src/ChunkCollection.ts",
 									"line": 136,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L136"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L136"
 								}
 							],
 							"signatures": [
@@ -2705,7 +2705,7 @@
 									"fileName": "src/ChunkCollection.ts",
 									"line": 48,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L48"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L48"
 								}
 							],
 							"signatures": [
@@ -2793,7 +2793,7 @@
 									"fileName": "src/ChunkCollection.ts",
 									"line": 81,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L81"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L81"
 								}
 							],
 							"signatures": [
@@ -2854,7 +2854,7 @@
 									"fileName": "src/ChunkCollection.ts",
 									"line": 71,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L71"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L71"
 								}
 							],
 							"signatures": [
@@ -2890,7 +2890,7 @@
 									"fileName": "src/ChunkCollection.ts",
 									"line": 185,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L185"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L185"
 								}
 							],
 							"signatures": [
@@ -2951,7 +2951,7 @@
 									"fileName": "src/ChunkCollection.ts",
 									"line": 122,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L122"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L122"
 								}
 							],
 							"signatures": [
@@ -2987,7 +2987,7 @@
 									"fileName": "src/ChunkCollection.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L105"
 								}
 							],
 							"signatures": [
@@ -3023,7 +3023,7 @@
 									"fileName": "src/ChunkCollection.ts",
 									"line": 97,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L97"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L97"
 								}
 							],
 							"signatures": [
@@ -3059,7 +3059,7 @@
 									"fileName": "src/ChunkCollection.ts",
 									"line": 115,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L115"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L115"
 								}
 							],
 							"signatures": [
@@ -3095,7 +3095,7 @@
 									"fileName": "src/ChunkCollection.ts",
 									"line": 60,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L60"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L60"
 								}
 							],
 							"signatures": [
@@ -3153,7 +3153,7 @@
 									"fileName": "src/ChunkCollection.ts",
 									"line": 175,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L175"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L175"
 								}
 							],
 							"signatures": [
@@ -3245,7 +3245,7 @@
 							"fileName": "src/ChunkCollection.ts",
 							"line": 9,
 							"character": 21,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L9"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L9"
 						}
 					]
 				}
@@ -3263,7 +3263,7 @@
 					"fileName": "src/ChunkCollection.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunkCollection.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunkCollection.ts#L1"
 				}
 			]
 		},
@@ -3300,7 +3300,7 @@
 									"fileName": "src/ChunksSlots.ts",
 									"line": 40,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L40"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L40"
 								}
 							],
 							"signatures": [
@@ -3360,7 +3360,7 @@
 									"fileName": "src/ChunksSlots.ts",
 									"line": 35,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L35"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L35"
 								}
 							],
 							"type": {
@@ -3390,7 +3390,7 @@
 									"fileName": "src/ChunksSlots.ts",
 									"line": 29,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L29"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L29"
 								}
 							],
 							"type": {
@@ -3420,7 +3420,7 @@
 									"fileName": "src/ChunksSlots.ts",
 									"line": 33,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L33"
 								}
 							],
 							"type": {
@@ -3454,7 +3454,7 @@
 									"fileName": "src/ChunksSlots.ts",
 									"line": 31,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L31"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L31"
 								}
 							],
 							"type": {
@@ -3492,7 +3492,7 @@
 									"fileName": "src/ChunksSlots.ts",
 									"line": 27,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L27"
 								}
 							],
 							"type": {
@@ -3511,7 +3511,7 @@
 									"fileName": "src/ChunksSlots.ts",
 									"line": 70,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L70"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L70"
 								}
 							],
 							"getSignature": {
@@ -3545,7 +3545,7 @@
 									"fileName": "src/ChunksSlots.ts",
 									"line": 77,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L77"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L77"
 								}
 							],
 							"getSignature": {
@@ -3579,7 +3579,7 @@
 									"fileName": "src/ChunksSlots.ts",
 									"line": 48,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L48"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L48"
 								}
 							],
 							"signatures": [
@@ -3637,7 +3637,7 @@
 									"fileName": "src/ChunksSlots.ts",
 									"line": 61,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L61"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L61"
 								}
 							],
 							"signatures": [
@@ -3722,7 +3722,7 @@
 							"fileName": "src/ChunksSlots.ts",
 							"line": 25,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L25"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L25"
 						}
 					]
 				},
@@ -3753,7 +3753,7 @@
 									"fileName": "src/ChunksSlots.ts",
 									"line": 97,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L97"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L97"
 								}
 							],
 							"signatures": [
@@ -3790,7 +3790,7 @@
 									"fileName": "src/ChunksSlots.ts",
 									"line": 90,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L90"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L90"
 								}
 							],
 							"type": {
@@ -3821,7 +3821,7 @@
 									"fileName": "src/ChunksSlots.ts",
 									"line": 92,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L92"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L92"
 								}
 							],
 							"type": {
@@ -3853,7 +3853,7 @@
 									"fileName": "src/ChunksSlots.ts",
 									"line": 134,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L134"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L134"
 								}
 							],
 							"signatures": [
@@ -3929,7 +3929,7 @@
 									"fileName": "src/ChunksSlots.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L105"
 								}
 							],
 							"signatures": [
@@ -3965,7 +3965,7 @@
 									"fileName": "src/ChunksSlots.ts",
 									"line": 117,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L117"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L117"
 								}
 							],
 							"signatures": [
@@ -4023,7 +4023,7 @@
 									"fileName": "src/ChunksSlots.ts",
 									"line": 142,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L142"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L142"
 								}
 							],
 							"signatures": [
@@ -4100,7 +4100,7 @@
 							"fileName": "src/ChunksSlots.ts",
 							"line": 88,
 							"character": 21,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L88"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L88"
 						}
 					]
 				},
@@ -4130,7 +4130,7 @@
 									"fileName": "src/ChunksSlots.ts",
 									"line": 15,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L15"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L15"
 								}
 							],
 							"signatures": [
@@ -4188,7 +4188,7 @@
 									"fileName": "src/ChunksSlots.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L8"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L8"
 								}
 							],
 							"type": {
@@ -4215,7 +4215,7 @@
 									"fileName": "src/ChunksSlots.ts",
 									"line": 10,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L10"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L10"
 								}
 							],
 							"type": {
@@ -4244,7 +4244,7 @@
 							"fileName": "src/ChunksSlots.ts",
 							"line": 6,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L6"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L6"
 						}
 					]
 				}
@@ -4264,7 +4264,7 @@
 					"fileName": "src/ChunksSlots.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ChunksSlots.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ChunksSlots.ts#L1"
 				}
 			]
 		},
@@ -4301,7 +4301,7 @@
 									"fileName": "src/ColorSpace.ts",
 									"line": 5,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ColorSpace.ts#L5"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ColorSpace.ts#L5"
 								}
 							],
 							"type": {
@@ -4320,7 +4320,7 @@
 									"fileName": "src/ColorSpace.ts",
 									"line": 7,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ColorSpace.ts#L7"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ColorSpace.ts#L7"
 								}
 							],
 							"type": {
@@ -4339,7 +4339,7 @@
 									"fileName": "src/ColorSpace.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ColorSpace.ts#L6"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ColorSpace.ts#L6"
 								}
 							],
 							"type": {
@@ -4363,7 +4363,7 @@
 							"fileName": "src/ColorSpace.ts",
 							"line": 4,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ColorSpace.ts#L4"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ColorSpace.ts#L4"
 						}
 					]
 				},
@@ -4389,7 +4389,7 @@
 							"fileName": "src/ColorSpace.ts",
 							"line": 20,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ColorSpace.ts#L20"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ColorSpace.ts#L20"
 						}
 					],
 					"type": {
@@ -4429,7 +4429,7 @@
 							"fileName": "src/ColorSpace.ts",
 							"line": 11,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ColorSpace.ts#L11"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ColorSpace.ts#L11"
 						}
 					],
 					"type": {
@@ -4479,7 +4479,7 @@
 					"fileName": "src/ColorSpace.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ColorSpace.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ColorSpace.ts#L1"
 				}
 			]
 		},
@@ -4502,7 +4502,7 @@
 							"fileName": "src/DepthFormatEnum.ts",
 							"line": 18,
 							"character": 0,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/DepthFormatEnum.ts#L18"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/DepthFormatEnum.ts#L18"
 						}
 					],
 					"target": 188
@@ -4529,7 +4529,7 @@
 							"fileName": "src/DepthFormatEnum.ts",
 							"line": 16,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/DepthFormatEnum.ts#L16"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/DepthFormatEnum.ts#L16"
 						}
 					],
 					"type": {
@@ -4569,7 +4569,7 @@
 							"fileName": "src/DepthFormatEnum.ts",
 							"line": 5,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/DepthFormatEnum.ts#L5"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/DepthFormatEnum.ts#L5"
 						}
 					],
 					"type": {
@@ -4617,7 +4617,7 @@
 					"fileName": "src/DepthFormatEnum.ts",
 					"line": 2,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/DepthFormatEnum.ts#L2"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/DepthFormatEnum.ts#L2"
 				}
 			]
 		},
@@ -4655,7 +4655,7 @@
 									"fileName": "src/DepthPass.ts",
 									"line": 34,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/DepthPass.ts#L34"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/DepthPass.ts#L34"
 								}
 							],
 							"signatures": [
@@ -4727,7 +4727,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 28,
 									"character": 24,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L28"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L28"
 								}
 							],
 							"type": {
@@ -4760,7 +4760,7 @@
 									"fileName": "src/DepthPass.ts",
 									"line": 27,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/DepthPass.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/DepthPass.ts#L27"
 								}
 							],
 							"type": {
@@ -4790,7 +4790,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 21,
 									"character": 13,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L21"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L21"
 								}
 							],
 							"type": {
@@ -4825,7 +4825,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 23,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L23"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L23"
 								}
 							],
 							"type": {
@@ -4859,7 +4859,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 18,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L18"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L18"
 								}
 							],
 							"type": {
@@ -4892,7 +4892,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 16,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L16"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L16"
 								}
 							],
 							"type": {
@@ -4925,7 +4925,7 @@
 									"fileName": "src/DepthPass.ts",
 									"line": 29,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/DepthPass.ts#L29"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/DepthPass.ts#L29"
 								}
 							],
 							"type": {
@@ -4945,7 +4945,7 @@
 									"fileName": "src/DepthPass.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/DepthPass.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/DepthPass.ts#L56"
 								}
 							],
 							"signatures": [
@@ -5064,7 +5064,7 @@
 									"fileName": "src/DepthPass.ts",
 									"line": 52,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/DepthPass.ts#L52"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/DepthPass.ts#L52"
 								}
 							],
 							"signatures": [
@@ -5144,7 +5144,7 @@
 							"fileName": "src/DepthPass.ts",
 							"line": 25,
 							"character": 21,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/DepthPass.ts#L25"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/DepthPass.ts#L25"
 						}
 					],
 					"extendedTypes": [
@@ -5169,7 +5169,7 @@
 					"fileName": "src/DepthPass.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/DepthPass.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/DepthPass.ts#L1"
 				}
 			]
 		},
@@ -5207,7 +5207,7 @@
 									"fileName": "src/Enum.ts",
 									"line": 44,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Enum.ts#L44"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Enum.ts#L44"
 								}
 							],
 							"signatures": [
@@ -5332,7 +5332,7 @@
 									"fileName": "src/Enum.ts",
 									"line": 37,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Enum.ts#L37"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Enum.ts#L37"
 								}
 							],
 							"type": {
@@ -5361,7 +5361,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -5399,7 +5399,7 @@
 									"fileName": "src/Enum.ts",
 									"line": 32,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Enum.ts#L32"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Enum.ts#L32"
 								}
 							],
 							"type": {
@@ -5428,7 +5428,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -5462,7 +5462,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -5496,7 +5496,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -5530,7 +5530,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -5581,7 +5581,7 @@
 									"fileName": "src/Enum.ts",
 									"line": 27,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Enum.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Enum.ts#L27"
 								}
 							],
 							"type": {
@@ -5618,7 +5618,7 @@
 									"fileName": "src/Enum.ts",
 									"line": 29,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Enum.ts#L29"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Enum.ts#L29"
 								}
 							],
 							"type": {
@@ -5645,7 +5645,7 @@
 									"fileName": "src/Enum.ts",
 									"line": 22,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Enum.ts#L22"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Enum.ts#L22"
 								}
 							],
 							"type": {
@@ -5672,7 +5672,7 @@
 									"fileName": "src/Enum.ts",
 									"line": 24,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Enum.ts#L24"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Enum.ts#L24"
 								}
 							],
 							"type": {
@@ -5692,7 +5692,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -5735,7 +5735,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -5778,7 +5778,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -5821,7 +5821,7 @@
 									"fileName": "src/Enum.ts",
 									"line": 112,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Enum.ts#L112"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Enum.ts#L112"
 								}
 							],
 							"signatures": [
@@ -5912,7 +5912,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -6010,7 +6010,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -6078,7 +6078,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -6182,7 +6182,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -6229,7 +6229,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -6297,7 +6297,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -6365,7 +6365,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -6411,7 +6411,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -6457,7 +6457,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -6542,7 +6542,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -6610,7 +6610,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -6678,7 +6678,7 @@
 									"fileName": "src/Enum.ts",
 									"line": 73,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Enum.ts#L73"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Enum.ts#L73"
 								}
 							],
 							"signatures": [
@@ -6743,7 +6743,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 172,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L172"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L172"
 								}
 							],
 							"signatures": [
@@ -6812,7 +6812,7 @@
 									"fileName": "src/Enum.ts",
 									"line": 61,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Enum.ts#L61"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Enum.ts#L61"
 								}
 							],
 							"signatures": [
@@ -6903,7 +6903,7 @@
 							"fileName": "src/Enum.ts",
 							"line": 20,
 							"character": 6,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Enum.ts#L20"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Enum.ts#L20"
 						}
 					],
 					"typeParameters": [
@@ -6956,7 +6956,7 @@
 					"fileName": "src/Enum.ts",
 					"line": 2,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Enum.ts#L2"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Enum.ts#L2"
 				}
 			]
 		},
@@ -6994,7 +6994,7 @@
 									"fileName": "src/Flag.ts",
 									"line": 25,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Flag.ts#L25"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Flag.ts#L25"
 								}
 							],
 							"signatures": [
@@ -7119,7 +7119,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -7157,7 +7157,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -7191,7 +7191,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -7225,7 +7225,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -7259,7 +7259,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -7310,7 +7310,7 @@
 									"fileName": "src/Flag.ts",
 									"line": 18,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Flag.ts#L18"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Flag.ts#L18"
 								}
 							],
 							"type": {
@@ -7337,7 +7337,7 @@
 									"fileName": "src/Flag.ts",
 									"line": 15,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Flag.ts#L15"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Flag.ts#L15"
 								}
 							],
 							"type": {
@@ -7357,7 +7357,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -7400,7 +7400,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -7443,7 +7443,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -7486,7 +7486,7 @@
 									"fileName": "src/Flag.ts",
 									"line": 67,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Flag.ts#L67"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Flag.ts#L67"
 								}
 							],
 							"getSignature": {
@@ -7520,7 +7520,7 @@
 									"fileName": "src/Flag.ts",
 									"line": 87,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Flag.ts#L87"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Flag.ts#L87"
 								}
 							],
 							"signatures": [
@@ -7611,7 +7611,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -7709,7 +7709,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -7777,7 +7777,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -7881,7 +7881,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -7928,7 +7928,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -7996,7 +7996,7 @@
 									"fileName": "src/Flag.ts",
 									"line": 45,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Flag.ts#L45"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Flag.ts#L45"
 								}
 							],
 							"signatures": [
@@ -8032,7 +8032,7 @@
 									"fileName": "src/Flag.ts",
 									"line": 37,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Flag.ts#L37"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Flag.ts#L37"
 								}
 							],
 							"signatures": [
@@ -8068,7 +8068,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -8136,7 +8136,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -8182,7 +8182,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -8228,7 +8228,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -8313,7 +8313,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -8381,7 +8381,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -8449,7 +8449,7 @@
 									"fileName": "src/Flag.ts",
 									"line": 57,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Flag.ts#L57"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Flag.ts#L57"
 								}
 							],
 							"signatures": [
@@ -8509,7 +8509,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 172,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L172"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L172"
 								}
 							],
 							"signatures": [
@@ -8623,7 +8623,7 @@
 							"fileName": "src/Flag.ts",
 							"line": 13,
 							"character": 6,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Flag.ts#L13"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Flag.ts#L13"
 						}
 					],
 					"typeParameters": [
@@ -8673,7 +8673,7 @@
 					"fileName": "src/Flag.ts",
 					"line": 2,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Flag.ts#L2"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Flag.ts#L2"
 				}
 			]
 		},
@@ -8706,7 +8706,7 @@
 							"fileName": "src/GammaModeEnum.ts",
 							"line": 22,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/GammaModeEnum.ts#L22"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/GammaModeEnum.ts#L22"
 						}
 					],
 					"type": {
@@ -8746,7 +8746,7 @@
 							"fileName": "src/GammaModeEnum.ts",
 							"line": 4,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/GammaModeEnum.ts#L4"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/GammaModeEnum.ts#L4"
 						}
 					],
 					"type": {
@@ -8796,7 +8796,7 @@
 					"fileName": "src/GammaModeEnum.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/GammaModeEnum.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/GammaModeEnum.ts#L1"
 				}
 			]
 		},
@@ -8864,7 +8864,7 @@
 									"fileName": "src/Hash.ts",
 									"line": 172,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Hash.ts#L172"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Hash.ts#L172"
 								}
 							],
 							"type": {
@@ -8884,7 +8884,7 @@
 									"fileName": "src/Hash.ts",
 									"line": 219,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Hash.ts#L219"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Hash.ts#L219"
 								}
 							],
 							"signatures": [
@@ -8920,7 +8920,7 @@
 									"fileName": "src/Hash.ts",
 									"line": 199,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Hash.ts#L199"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Hash.ts#L199"
 								}
 							],
 							"signatures": [
@@ -8978,7 +8978,7 @@
 									"fileName": "src/Hash.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Hash.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Hash.ts#L188"
 								}
 							],
 							"signatures": [
@@ -9036,7 +9036,7 @@
 									"fileName": "src/Hash.ts",
 									"line": 210,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Hash.ts#L210"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Hash.ts#L210"
 								}
 							],
 							"signatures": [
@@ -9096,7 +9096,7 @@
 									"fileName": "src/Hash.ts",
 									"line": 177,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Hash.ts#L177"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Hash.ts#L177"
 								}
 							],
 							"signatures": [
@@ -9152,7 +9152,7 @@
 							"fileName": "src/Hash.ts",
 							"line": 170,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Hash.ts#L170"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Hash.ts#L170"
 						}
 					]
 				},
@@ -9175,7 +9175,7 @@
 							"fileName": "src/Hash.ts",
 							"line": 2,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Hash.ts#L2"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Hash.ts#L2"
 						}
 					],
 					"type": {
@@ -9197,7 +9197,7 @@
 							"fileName": "src/Hash.ts",
 							"line": 227,
 							"character": 6,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Hash.ts#L227"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Hash.ts#L227"
 						}
 					],
 					"type": {
@@ -9218,7 +9218,7 @@
 							"fileName": "src/Hash.ts",
 							"line": 111,
 							"character": 16,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Hash.ts#L111"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Hash.ts#L111"
 						}
 					],
 					"signatures": [
@@ -9298,7 +9298,7 @@
 							"fileName": "src/Hash.ts",
 							"line": 88,
 							"character": 16,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Hash.ts#L88"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Hash.ts#L88"
 						}
 					],
 					"signatures": [
@@ -9378,7 +9378,7 @@
 							"fileName": "src/Hash.ts",
 							"line": 137,
 							"character": 16,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Hash.ts#L137"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Hash.ts#L137"
 						}
 					],
 					"signatures": [
@@ -9460,7 +9460,7 @@
 							"fileName": "src/Hash.ts",
 							"line": 124,
 							"character": 16,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Hash.ts#L124"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Hash.ts#L124"
 						}
 					],
 					"signatures": [
@@ -9536,7 +9536,7 @@
 							"fileName": "src/Hash.ts",
 							"line": 160,
 							"character": 16,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Hash.ts#L160"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Hash.ts#L160"
 						}
 					],
 					"signatures": [
@@ -9618,7 +9618,7 @@
 					"fileName": "src/Hash.ts",
 					"line": 2,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Hash.ts#L2"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Hash.ts#L2"
 				}
 			]
 		},
@@ -9663,7 +9663,7 @@
 									"fileName": "src/Input.ts",
 									"line": 103,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L103"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L103"
 								}
 							],
 							"type": {
@@ -9690,7 +9690,7 @@
 									"fileName": "src/Input.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L105"
 								}
 							],
 							"type": {
@@ -9717,7 +9717,7 @@
 									"fileName": "src/Input.ts",
 									"line": 99,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L99"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L99"
 								}
 							],
 							"type": {
@@ -9744,7 +9744,7 @@
 									"fileName": "src/Input.ts",
 									"line": 101,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L101"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L101"
 								}
 							],
 							"type": {
@@ -9769,7 +9769,7 @@
 							"fileName": "src/Input.ts",
 							"line": 97,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L97"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L97"
 						}
 					]
 				},
@@ -9799,7 +9799,7 @@
 									"fileName": "src/Input.ts",
 									"line": 26,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L26"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L26"
 								}
 							],
 							"type": {
@@ -9818,7 +9818,7 @@
 									"fileName": "src/Input.ts",
 									"line": 24,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L24"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L24"
 								}
 							],
 							"type": {
@@ -9837,7 +9837,7 @@
 									"fileName": "src/Input.ts",
 									"line": 25,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L25"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L25"
 								}
 							],
 							"type": {
@@ -9861,7 +9861,7 @@
 							"fileName": "src/Input.ts",
 							"line": 23,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L23"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L23"
 						}
 					]
 				},
@@ -9891,7 +9891,7 @@
 									"fileName": "src/Input.ts",
 									"line": 508,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L508"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L508"
 								}
 							],
 							"signatures": [
@@ -9981,7 +9981,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -10019,7 +10019,7 @@
 									"fileName": "src/Input.ts",
 									"line": 152,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L152"
 								}
 							],
 							"type": {
@@ -10055,7 +10055,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -10089,7 +10089,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -10123,7 +10123,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -10157,7 +10157,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -10199,7 +10199,7 @@
 									"fileName": "src/Input.ts",
 									"line": 500,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L500"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L500"
 								}
 							],
 							"type": {
@@ -10233,7 +10233,7 @@
 									"fileName": "src/Input.ts",
 									"line": 498,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L498"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L498"
 								}
 							],
 							"type": {
@@ -10267,7 +10267,7 @@
 									"fileName": "src/Input.ts",
 									"line": 501,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L501"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L501"
 								}
 							],
 							"type": {
@@ -10300,7 +10300,7 @@
 									"fileName": "src/Input.ts",
 									"line": 502,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L502"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L502"
 								}
 							],
 							"type": {
@@ -10324,13 +10324,13 @@
 									"fileName": "src/Input.ts",
 									"line": 168,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L168"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L168"
 								},
 								{
 									"fileName": "src/Input.ts",
 									"line": 178,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L178"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L178"
 								}
 							],
 							"getSignature": {
@@ -10419,7 +10419,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -10462,7 +10462,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -10505,7 +10505,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -10550,7 +10550,7 @@
 									"fileName": "src/Input.ts",
 									"line": 521,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L521"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L521"
 								}
 							],
 							"signatures": [
@@ -10610,7 +10610,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -10708,7 +10708,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -10776,7 +10776,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -10880,7 +10880,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -10927,7 +10927,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -10995,7 +10995,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -11063,7 +11063,7 @@
 									"fileName": "src/Input.ts",
 									"line": 534,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L534"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L534"
 								}
 							],
 							"signatures": [
@@ -11151,7 +11151,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -11197,7 +11197,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -11243,7 +11243,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -11321,7 +11321,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -11389,7 +11389,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -11457,7 +11457,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 172,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L172"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L172"
 								}
 							],
 							"signatures": [
@@ -11572,7 +11572,7 @@
 							"fileName": "src/Input.ts",
 							"line": 496,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L496"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L496"
 						}
 					],
 					"extendedTypes": [
@@ -11618,7 +11618,7 @@
 									"fileName": "src/Input.ts",
 									"line": 158,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L158"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L158"
 								}
 							],
 							"signatures": [
@@ -11713,7 +11713,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -11751,7 +11751,7 @@
 									"fileName": "src/Input.ts",
 									"line": 152,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L152"
 								}
 							],
 							"type": {
@@ -11782,7 +11782,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -11816,7 +11816,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -11850,7 +11850,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -11884,7 +11884,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -11918,13 +11918,13 @@
 									"fileName": "src/Input.ts",
 									"line": 168,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L168"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L168"
 								},
 								{
 									"fileName": "src/Input.ts",
 									"line": 178,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L178"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L178"
 								}
 							],
 							"getSignature": {
@@ -12000,7 +12000,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -12043,7 +12043,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -12086,7 +12086,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -12132,7 +12132,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 166,
 									"character": 21,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L166"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L166"
 								}
 							],
 							"signatures": [
@@ -12209,7 +12209,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -12307,7 +12307,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -12375,7 +12375,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -12479,7 +12479,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -12526,7 +12526,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -12594,7 +12594,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -12662,7 +12662,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -12708,7 +12708,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -12754,7 +12754,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -12832,7 +12832,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -12900,7 +12900,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -12968,7 +12968,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 172,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L172"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L172"
 								}
 							],
 							"signatures": [
@@ -13078,7 +13078,7 @@
 							"fileName": "src/Input.ts",
 							"line": 150,
 							"character": 22,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L150"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L150"
 						}
 					],
 					"extendedTypes": [
@@ -13137,7 +13137,7 @@
 									"fileName": "src/Input.ts",
 									"line": 588,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L588"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L588"
 								}
 							],
 							"signatures": [
@@ -13224,7 +13224,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -13262,7 +13262,7 @@
 									"fileName": "src/Input.ts",
 									"line": 152,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L152"
 								}
 							],
 							"type": {
@@ -13298,7 +13298,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -13332,7 +13332,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -13364,7 +13364,7 @@
 									"fileName": "src/Input.ts",
 									"line": 583,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L583"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L583"
 								}
 							],
 							"type": {
@@ -13394,7 +13394,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -13428,7 +13428,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -13470,7 +13470,7 @@
 									"fileName": "src/Input.ts",
 									"line": 577,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L577"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L577"
 								}
 							],
 							"type": {
@@ -13505,7 +13505,7 @@
 									"fileName": "src/Input.ts",
 									"line": 575,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L575"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L575"
 								}
 							],
 							"type": {
@@ -13539,7 +13539,7 @@
 									"fileName": "src/Input.ts",
 									"line": 578,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L578"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L578"
 								}
 							],
 							"type": {
@@ -13573,7 +13573,7 @@
 									"fileName": "src/Input.ts",
 									"line": 579,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L579"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L579"
 								}
 							],
 							"type": {
@@ -13606,7 +13606,7 @@
 									"fileName": "src/Input.ts",
 									"line": 581,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L581"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L581"
 								}
 							],
 							"type": {
@@ -13643,13 +13643,13 @@
 									"fileName": "src/Input.ts",
 									"line": 168,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L168"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L168"
 								},
 								{
 									"fileName": "src/Input.ts",
 									"line": 178,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L178"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L178"
 								}
 							],
 							"getSignature": {
@@ -13738,7 +13738,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -13781,7 +13781,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -13824,7 +13824,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -13869,7 +13869,7 @@
 									"fileName": "src/Input.ts",
 									"line": 622,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L622"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L622"
 								}
 							],
 							"signatures": [
@@ -13929,7 +13929,7 @@
 									"fileName": "src/Input.ts",
 									"line": 645,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L645"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L645"
 								}
 							],
 							"signatures": [
@@ -13965,7 +13965,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -14063,7 +14063,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -14131,7 +14131,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -14235,7 +14235,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -14282,7 +14282,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -14350,7 +14350,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -14418,7 +14418,7 @@
 									"fileName": "src/Input.ts",
 									"line": 636,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L636"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L636"
 								}
 							],
 							"signatures": [
@@ -14506,7 +14506,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -14552,7 +14552,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -14598,7 +14598,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -14676,7 +14676,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -14744,7 +14744,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -14812,7 +14812,7 @@
 									"fileName": "src/Input.ts",
 									"line": 599,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L599"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L599"
 								}
 							],
 							"signatures": [
@@ -14886,7 +14886,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 172,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L172"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L172"
 								}
 							],
 							"signatures": [
@@ -15005,7 +15005,7 @@
 							"fileName": "src/Input.ts",
 							"line": 573,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L573"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L573"
 						}
 					],
 					"extendedTypes": [
@@ -15060,7 +15060,7 @@
 									"fileName": "src/Input.ts",
 									"line": 704,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L704"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L704"
 								}
 							],
 							"signatures": [
@@ -15196,7 +15196,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -15234,7 +15234,7 @@
 									"fileName": "src/Input.ts",
 									"line": 690,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L690"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L690"
 								}
 							],
 							"type": {
@@ -15265,7 +15265,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -15299,7 +15299,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -15333,7 +15333,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -15367,7 +15367,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -15409,7 +15409,7 @@
 									"fileName": "src/Input.ts",
 									"line": 693,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L693"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L693"
 								}
 							],
 							"type": {
@@ -15439,7 +15439,7 @@
 									"fileName": "src/Input.ts",
 									"line": 683,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L683"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L683"
 								}
 							],
 							"type": {
@@ -15466,7 +15466,7 @@
 									"fileName": "src/Input.ts",
 									"line": 695,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L695"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L695"
 								}
 							],
 							"type": {
@@ -15505,7 +15505,7 @@
 									"fileName": "src/Input.ts",
 									"line": 687,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L687"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L687"
 								}
 							],
 							"type": {
@@ -15535,7 +15535,7 @@
 									"fileName": "src/Input.ts",
 									"line": 685,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L685"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L685"
 								}
 							],
 							"type": {
@@ -15566,7 +15566,7 @@
 									"fileName": "src/Input.ts",
 									"line": 680,
 									"character": 18,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L680"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L680"
 								}
 							],
 							"type": {
@@ -15598,7 +15598,7 @@
 									"fileName": "src/Input.ts",
 									"line": 671,
 									"character": 18,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L671"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L671"
 								}
 							],
 							"type": {
@@ -15633,7 +15633,7 @@
 									"fileName": "src/Input.ts",
 									"line": 673,
 									"character": 18,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L673"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L673"
 								}
 							],
 							"type": {
@@ -15668,7 +15668,7 @@
 									"fileName": "src/Input.ts",
 									"line": 676,
 									"character": 18,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L676"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L676"
 								}
 							],
 							"type": {
@@ -15700,7 +15700,7 @@
 									"fileName": "src/Input.ts",
 									"line": 667,
 									"character": 18,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L667"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L667"
 								}
 							],
 							"type": {
@@ -15735,7 +15735,7 @@
 									"fileName": "src/Input.ts",
 									"line": 669,
 									"character": 18,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L669"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L669"
 								}
 							],
 							"type": {
@@ -15770,7 +15770,7 @@
 									"fileName": "src/Input.ts",
 									"line": 678,
 									"character": 18,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L678"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L678"
 								}
 							],
 							"type": {
@@ -15791,13 +15791,13 @@
 									"fileName": "src/Input.ts",
 									"line": 730,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L730"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L730"
 								},
 								{
 									"fileName": "src/Input.ts",
 									"line": 740,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L740"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L740"
 								}
 							],
 							"getSignature": {
@@ -15873,7 +15873,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -15916,7 +15916,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -15959,7 +15959,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -16002,7 +16002,7 @@
 									"fileName": "src/Input.ts",
 									"line": 836,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L836"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L836"
 								}
 							],
 							"signatures": [
@@ -16078,7 +16078,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -16176,7 +16176,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -16244,7 +16244,7 @@
 									"fileName": "src/Input.ts",
 									"line": 750,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L750"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L750"
 								}
 							],
 							"signatures": [
@@ -16334,7 +16334,7 @@
 									"fileName": "src/Input.ts",
 									"line": 802,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L802"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L802"
 								}
 							],
 							"signatures": [
@@ -16441,7 +16441,7 @@
 									"fileName": "src/Input.ts",
 									"line": 813,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L813"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L813"
 								}
 							],
 							"signatures": [
@@ -16531,7 +16531,7 @@
 									"fileName": "src/Input.ts",
 									"line": 778,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L778"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L778"
 								}
 							],
 							"signatures": [
@@ -16647,7 +16647,7 @@
 									"fileName": "src/Input.ts",
 									"line": 790,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L790"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L790"
 								}
 							],
 							"signatures": [
@@ -16754,7 +16754,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -16858,7 +16858,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -16905,7 +16905,7 @@
 									"fileName": "src/Input.ts",
 									"line": 764,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L764"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L764"
 								}
 							],
 							"signatures": [
@@ -16941,7 +16941,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -17009,7 +17009,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -17077,7 +17077,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -17123,7 +17123,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -17169,7 +17169,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -17247,7 +17247,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -17315,7 +17315,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -17383,7 +17383,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 172,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L172"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L172"
 								}
 							],
 							"signatures": [
@@ -17511,7 +17511,7 @@
 							"fileName": "src/Input.ts",
 							"line": 664,
 							"character": 21,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L664"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L664"
 						}
 					],
 					"extendedTypes": [
@@ -17548,7 +17548,7 @@
 									"fileName": "src/Input.ts",
 									"line": 231,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L231"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L231"
 								}
 							],
 							"signatures": [
@@ -17673,7 +17673,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -17711,7 +17711,7 @@
 									"fileName": "src/Input.ts",
 									"line": 152,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L152"
 								}
 							],
 							"type": {
@@ -17747,7 +17747,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -17781,7 +17781,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -17815,7 +17815,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -17849,7 +17849,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -17891,7 +17891,7 @@
 									"fileName": "src/Input.ts",
 									"line": 215,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L215"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L215"
 								}
 							],
 							"type": {
@@ -17929,7 +17929,7 @@
 									"fileName": "src/Input.ts",
 									"line": 223,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L223"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L223"
 								}
 							],
 							"type": {
@@ -17956,7 +17956,7 @@
 									"fileName": "src/Input.ts",
 									"line": 211,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L211"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L211"
 								}
 							],
 							"type": {
@@ -17990,7 +17990,7 @@
 									"fileName": "src/Input.ts",
 									"line": 209,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L209"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L209"
 								}
 							],
 							"type": {
@@ -18024,7 +18024,7 @@
 									"fileName": "src/Input.ts",
 									"line": 212,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L212"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L212"
 								}
 							],
 							"type": {
@@ -18057,7 +18057,7 @@
 									"fileName": "src/Input.ts",
 									"line": 221,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L221"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L221"
 								}
 							],
 							"type": {
@@ -18094,7 +18094,7 @@
 									"fileName": "src/Input.ts",
 									"line": 213,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L213"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L213"
 								}
 							],
 							"type": {
@@ -18118,13 +18118,13 @@
 									"fileName": "src/Input.ts",
 									"line": 168,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L168"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L168"
 								},
 								{
 									"fileName": "src/Input.ts",
 									"line": 178,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L178"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L178"
 								}
 							],
 							"getSignature": {
@@ -18213,7 +18213,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -18256,7 +18256,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -18299,7 +18299,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -18344,7 +18344,7 @@
 									"fileName": "src/Input.ts",
 									"line": 263,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L263"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L263"
 								}
 							],
 							"signatures": [
@@ -18404,7 +18404,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -18502,7 +18502,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -18570,7 +18570,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -18674,7 +18674,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -18721,7 +18721,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -18789,7 +18789,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -18857,7 +18857,7 @@
 									"fileName": "src/Input.ts",
 									"line": 275,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L275"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L275"
 								}
 							],
 							"signatures": [
@@ -18945,7 +18945,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -18991,7 +18991,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -19037,7 +19037,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -19115,7 +19115,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -19183,7 +19183,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -19251,7 +19251,7 @@
 									"fileName": "src/Input.ts",
 									"line": 256,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L256"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L256"
 								}
 							],
 							"signatures": [
@@ -19310,7 +19310,7 @@
 									"fileName": "src/Input.ts",
 									"line": 291,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L291"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L291"
 								}
 							],
 							"signatures": [
@@ -19382,7 +19382,7 @@
 									"fileName": "src/Input.ts",
 									"line": 302,
 									"character": 17,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L302"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L302"
 								}
 							],
 							"signatures": [
@@ -19530,7 +19530,7 @@
 							"fileName": "src/Input.ts",
 							"line": 207,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L207"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L207"
 						}
 					],
 					"extendedTypes": [
@@ -19574,7 +19574,7 @@
 									"fileName": "src/Input.ts",
 									"line": 400,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L400"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L400"
 								}
 							],
 							"signatures": [
@@ -19664,7 +19664,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -19702,7 +19702,7 @@
 									"fileName": "src/Input.ts",
 									"line": 152,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L152"
 								}
 							],
 							"type": {
@@ -19738,7 +19738,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -19772,7 +19772,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -19806,7 +19806,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -19840,7 +19840,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -19884,7 +19884,7 @@
 									"fileName": "src/Input.ts",
 									"line": 343,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L343"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L343"
 								}
 							],
 							"type": {
@@ -19915,7 +19915,7 @@
 									"fileName": "src/Input.ts",
 									"line": 338,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L338"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L338"
 								}
 							],
 							"type": {
@@ -19949,7 +19949,7 @@
 									"fileName": "src/Input.ts",
 									"line": 336,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L336"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L336"
 								}
 							],
 							"type": {
@@ -19985,7 +19985,7 @@
 									"fileName": "src/Input.ts",
 									"line": 339,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L339"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L339"
 								}
 							],
 							"type": {
@@ -20018,7 +20018,7 @@
 									"fileName": "src/Input.ts",
 									"line": 340,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L340"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L340"
 								}
 							],
 							"type": {
@@ -20042,13 +20042,13 @@
 									"fileName": "src/Input.ts",
 									"line": 168,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L168"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L168"
 								},
 								{
 									"fileName": "src/Input.ts",
 									"line": 178,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L178"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L178"
 								}
 							],
 							"getSignature": {
@@ -20137,7 +20137,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -20180,7 +20180,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -20223,7 +20223,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -20268,7 +20268,7 @@
 									"fileName": "src/Input.ts",
 									"line": 346,
 									"character": 13,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L346"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L346"
 								}
 							],
 							"getSignature": {
@@ -20306,13 +20306,13 @@
 									"fileName": "src/Input.ts",
 									"line": 373,
 									"character": 13,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L373"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L373"
 								},
 								{
 									"fileName": "src/Input.ts",
 									"line": 394,
 									"character": 13,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L394"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L394"
 								}
 							],
 							"getSignature": {
@@ -20388,13 +20388,13 @@
 									"fileName": "src/Input.ts",
 									"line": 355,
 									"character": 13,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L355"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L355"
 								},
 								{
 									"fileName": "src/Input.ts",
 									"line": 379,
 									"character": 13,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L379"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L379"
 								}
 							],
 							"getSignature": {
@@ -20470,13 +20470,13 @@
 									"fileName": "src/Input.ts",
 									"line": 361,
 									"character": 13,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L361"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L361"
 								},
 								{
 									"fileName": "src/Input.ts",
 									"line": 384,
 									"character": 13,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L384"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L384"
 								}
 							],
 							"getSignature": {
@@ -20552,13 +20552,13 @@
 									"fileName": "src/Input.ts",
 									"line": 367,
 									"character": 13,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L367"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L367"
 								},
 								{
 									"fileName": "src/Input.ts",
 									"line": 389,
 									"character": 13,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L389"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L389"
 								}
 							],
 							"getSignature": {
@@ -20634,7 +20634,7 @@
 									"fileName": "src/Input.ts",
 									"line": 427,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L427"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L427"
 								}
 							],
 							"signatures": [
@@ -20694,7 +20694,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -20792,7 +20792,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -20860,7 +20860,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -20964,7 +20964,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -21011,7 +21011,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -21079,7 +21079,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -21147,7 +21147,7 @@
 									"fileName": "src/Input.ts",
 									"line": 440,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L440"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L440"
 								}
 							],
 							"signatures": [
@@ -21235,7 +21235,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -21281,7 +21281,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -21327,7 +21327,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -21405,7 +21405,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -21473,7 +21473,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -21541,7 +21541,7 @@
 									"fileName": "src/Input.ts",
 									"line": 417,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L417"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L417"
 								}
 							],
 							"signatures": [
@@ -21603,7 +21603,7 @@
 									"fileName": "src/Input.ts",
 									"line": 453,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L453"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L453"
 								}
 							],
 							"signatures": [
@@ -21674,7 +21674,7 @@
 									"fileName": "src/Input.ts",
 									"line": 465,
 									"character": 9,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L465"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L465"
 								}
 							],
 							"signatures": [
@@ -21844,7 +21844,7 @@
 							"fileName": "src/Input.ts",
 							"line": 334,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L334"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L334"
 						}
 					],
 					"extendedTypes": [
@@ -21896,7 +21896,7 @@
 									"fileName": "src/Input.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L119"
 								}
 							],
 							"type": {
@@ -21925,7 +21925,7 @@
 									"fileName": "src/Input.ts",
 									"line": 117,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L117"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L117"
 								}
 							],
 							"type": {
@@ -21953,7 +21953,7 @@
 									"fileName": "src/Input.ts",
 									"line": 121,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L121"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L121"
 								}
 							],
 							"type": {
@@ -21981,7 +21981,7 @@
 									"fileName": "src/Input.ts",
 									"line": 126,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L126"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L126"
 								}
 							],
 							"type": {
@@ -22000,7 +22000,7 @@
 									"fileName": "src/Input.ts",
 									"line": 133,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L133"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L133"
 								}
 							],
 							"signatures": [
@@ -22090,7 +22090,7 @@
 							"fileName": "src/Input.ts",
 							"line": 115,
 							"character": 17,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L115"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L115"
 						}
 					],
 					"implementedBy": [
@@ -22145,7 +22145,7 @@
 							"fileName": "src/Input.ts",
 							"line": 138,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L138"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L138"
 						}
 					],
 					"type": {
@@ -22209,7 +22209,7 @@
 							"fileName": "src/Input.ts",
 							"line": 30,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L30"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L30"
 						}
 					],
 					"type": {
@@ -22273,7 +22273,7 @@
 					"fileName": "src/Input.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Input.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Input.ts#L1"
 				}
 			]
 		},
@@ -22311,7 +22311,7 @@
 									"fileName": "src/Material.ts",
 									"line": 91,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L91"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L91"
 								}
 							],
 							"signatures": [
@@ -22393,7 +22393,7 @@
 									"fileName": "src/Material.ts",
 									"line": 83,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L83"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L83"
 								}
 							],
 							"type": {
@@ -22434,7 +22434,7 @@
 									"fileName": "src/Material.ts",
 									"line": 85,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L85"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L85"
 								}
 							],
 							"type": {
@@ -22468,7 +22468,7 @@
 									"fileName": "src/Material.ts",
 									"line": 91,
 									"character": 24,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L91"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L91"
 								}
 							],
 							"type": {
@@ -22499,7 +22499,7 @@
 									"fileName": "src/Material.ts",
 									"line": 78,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L78"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L78"
 								}
 							],
 							"type": {
@@ -22531,7 +22531,7 @@
 									"fileName": "src/Material.ts",
 									"line": 80,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L80"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L80"
 								}
 							],
 							"type": {
@@ -22560,7 +22560,7 @@
 									"fileName": "src/Material.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L75"
 								}
 							],
 							"type": {
@@ -22590,7 +22590,7 @@
 									"fileName": "src/Material.ts",
 									"line": 91,
 									"character": 47,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L91"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L91"
 								}
 							],
 							"type": {
@@ -22610,7 +22610,7 @@
 									"fileName": "src/Material.ts",
 									"line": 99,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L99"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L99"
 								}
 							],
 							"signatures": [
@@ -22689,7 +22689,7 @@
 									"fileName": "src/Material.ts",
 									"line": 141,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L141"
 								}
 							],
 							"signatures": [
@@ -22729,7 +22729,7 @@
 									"fileName": "src/Material.ts",
 									"line": 126,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L126"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L126"
 								}
 							],
 							"signatures": [
@@ -22797,7 +22797,7 @@
 									"fileName": "src/Material.ts",
 									"line": 149,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L149"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L149"
 								}
 							],
 							"signatures": [
@@ -22865,7 +22865,7 @@
 									"fileName": "src/Material.ts",
 									"line": 134,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L134"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L134"
 								}
 							],
 							"signatures": [
@@ -22922,7 +22922,7 @@
 									"fileName": "src/Material.ts",
 									"line": 113,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L113"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L113"
 								}
 							],
 							"signatures": [
@@ -23005,7 +23005,7 @@
 							"fileName": "src/Material.ts",
 							"line": 73,
 							"character": 21,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L73"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L73"
 						}
 					]
 				},
@@ -23035,7 +23035,7 @@
 									"fileName": "src/Material.ts",
 									"line": 38,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L38"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L38"
 								}
 							],
 							"signatures": [
@@ -23116,7 +23116,7 @@
 									"fileName": "src/Material.ts",
 									"line": 24,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L24"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L24"
 								}
 							],
 							"type": {
@@ -23146,7 +23146,7 @@
 									"fileName": "src/Material.ts",
 									"line": 22,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L22"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L22"
 								}
 							],
 							"type": {
@@ -23176,7 +23176,7 @@
 									"fileName": "src/Material.ts",
 									"line": 29,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L29"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L29"
 								}
 							],
 							"type": {
@@ -23196,7 +23196,7 @@
 									"fileName": "src/Material.ts",
 									"line": 61,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L61"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L61"
 								}
 							],
 							"signatures": [
@@ -23234,7 +23234,7 @@
 									"fileName": "src/Material.ts",
 									"line": 52,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L52"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L52"
 								}
 							],
 							"signatures": [
@@ -23342,7 +23342,7 @@
 							"fileName": "src/Material.ts",
 							"line": 20,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L20"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L20"
 						}
 					]
 				}
@@ -23361,7 +23361,7 @@
 					"fileName": "src/Material.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Material.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Material.ts#L1"
 				}
 			]
 		},
@@ -23401,7 +23401,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 28,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L28"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L28"
 								}
 							],
 							"signatures": [
@@ -23462,7 +23462,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 28,
 									"character": 24,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L28"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L28"
 								}
 							],
 							"type": {
@@ -23492,7 +23492,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 21,
 									"character": 13,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L21"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L21"
 								}
 							],
 							"type": {
@@ -23522,7 +23522,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 23,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L23"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L23"
 								}
 							],
 							"type": {
@@ -23551,7 +23551,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 18,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L18"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L18"
 								}
 							],
 							"type": {
@@ -23579,7 +23579,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 16,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L16"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L16"
 								}
 							],
 							"type": {
@@ -23601,7 +23601,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 36,
 									"character": 13,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L36"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L36"
 								}
 							],
 							"signatures": [
@@ -23729,7 +23729,7 @@
 							"fileName": "src/MaterialPass.ts",
 							"line": 14,
 							"character": 30,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L14"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L14"
 						}
 					],
 					"extendedBy": [
@@ -23769,7 +23769,7 @@
 							"fileName": "src/MaterialPass.ts",
 							"line": 9,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L9"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L9"
 						}
 					],
 					"type": {
@@ -23810,7 +23810,7 @@
 					"fileName": "src/MaterialPass.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L1"
 				}
 			]
 		},
@@ -23851,7 +23851,7 @@
 							"fileName": "src/MorphCode.ts",
 							"line": 25,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphCode.ts#L25"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphCode.ts#L25"
 						}
 					],
 					"type": {
@@ -23882,7 +23882,7 @@
 											"fileName": "src/MorphCode.ts",
 											"line": 31,
 											"character": 2,
-											"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphCode.ts#L31"
+											"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphCode.ts#L31"
 										}
 									],
 									"type": {
@@ -23912,7 +23912,7 @@
 											"fileName": "src/MorphCode.ts",
 											"line": 29,
 											"character": 2,
-											"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphCode.ts#L29"
+											"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphCode.ts#L29"
 										}
 									],
 									"type": {
@@ -23940,7 +23940,7 @@
 											"fileName": "src/MorphCode.ts",
 											"line": 27,
 											"character": 2,
-											"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphCode.ts#L27"
+											"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphCode.ts#L27"
 										}
 									],
 									"type": {
@@ -23965,7 +23965,7 @@
 									"fileName": "src/MorphCode.ts",
 									"line": 25,
 									"character": 31,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphCode.ts#L25"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphCode.ts#L25"
 								}
 							]
 						}
@@ -23990,7 +23990,7 @@
 							"fileName": "src/MorphCode.ts",
 							"line": 9,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphCode.ts#L9"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphCode.ts#L9"
 						}
 					],
 					"type": {
@@ -24030,7 +24030,7 @@
 							"fileName": "src/MorphCode.ts",
 							"line": 7,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphCode.ts#L7"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphCode.ts#L7"
 						}
 					],
 					"type": {
@@ -24077,7 +24077,7 @@
 							"fileName": "src/MorphCode.ts",
 							"line": 96,
 							"character": 6,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphCode.ts#L96"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphCode.ts#L96"
 						}
 					],
 					"type": {
@@ -24100,7 +24100,7 @@
 											"fileName": "src/MorphCode.ts",
 											"line": 101,
 											"character": 2,
-											"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphCode.ts#L101"
+											"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphCode.ts#L101"
 										}
 									],
 									"signatures": [
@@ -24158,7 +24158,7 @@
 											"fileName": "src/MorphCode.ts",
 											"line": 112,
 											"character": 2,
-											"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphCode.ts#L112"
+											"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphCode.ts#L112"
 										}
 									],
 									"signatures": [
@@ -24220,7 +24220,7 @@
 									"fileName": "src/MorphCode.ts",
 									"line": 96,
 									"character": 18,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphCode.ts#L96"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphCode.ts#L96"
 								}
 							]
 						}
@@ -24248,7 +24248,7 @@
 							"fileName": "src/MorphCode.ts",
 							"line": 4,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphCode.ts#L4"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphCode.ts#L4"
 						}
 					],
 					"type": {
@@ -24280,7 +24280,7 @@
 					"fileName": "src/MorphCode.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphCode.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphCode.ts#L1"
 				}
 			]
 		},
@@ -24326,7 +24326,7 @@
 									"fileName": "src/MorphDeformer.ts",
 									"line": 39,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphDeformer.ts#L39"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphDeformer.ts#L39"
 								}
 							],
 							"signatures": [
@@ -24400,7 +24400,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -24438,7 +24438,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -24472,7 +24472,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -24506,7 +24506,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -24540,7 +24540,7 @@
 									"fileName": "src/MorphDeformer.ts",
 									"line": 32,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphDeformer.ts#L32"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphDeformer.ts#L32"
 								}
 							],
 							"type": {
@@ -24574,7 +24574,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -24618,7 +24618,7 @@
 									"fileName": "src/MorphDeformer.ts",
 									"line": 34,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphDeformer.ts#L34"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphDeformer.ts#L34"
 								}
 							],
 							"type": {
@@ -24639,7 +24639,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -24682,7 +24682,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -24725,7 +24725,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -24768,7 +24768,7 @@
 									"fileName": "src/MorphDeformer.ts",
 									"line": 76,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphDeformer.ts#L76"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphDeformer.ts#L76"
 								}
 							],
 							"getSignature": {
@@ -24806,7 +24806,7 @@
 									"fileName": "src/MorphDeformer.ts",
 									"line": 69,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphDeformer.ts#L69"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphDeformer.ts#L69"
 								}
 							],
 							"getSignature": {
@@ -24840,13 +24840,13 @@
 									"fileName": "src/MorphDeformer.ts",
 									"line": 50,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphDeformer.ts#L50"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphDeformer.ts#L50"
 								},
 								{
 									"fileName": "src/MorphDeformer.ts",
 									"line": 60,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphDeformer.ts#L60"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphDeformer.ts#L60"
 								}
 							],
 							"getSignature": {
@@ -24926,7 +24926,7 @@
 									"fileName": "src/MorphDeformer.ts",
 									"line": 92,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphDeformer.ts#L92"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphDeformer.ts#L92"
 								}
 							],
 							"signatures": [
@@ -24996,7 +24996,7 @@
 									"fileName": "src/MorphDeformer.ts",
 									"line": 100,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphDeformer.ts#L100"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphDeformer.ts#L100"
 								}
 							],
 							"signatures": [
@@ -25032,7 +25032,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -25130,7 +25130,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -25198,7 +25198,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -25302,7 +25302,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -25349,7 +25349,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -25417,7 +25417,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -25485,7 +25485,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -25531,7 +25531,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -25577,7 +25577,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -25655,7 +25655,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -25723,7 +25723,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -25791,7 +25791,7 @@
 									"fileName": "src/MorphDeformer.ts",
 									"line": 84,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphDeformer.ts#L84"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphDeformer.ts#L84"
 								}
 							],
 							"signatures": [
@@ -25905,7 +25905,7 @@
 							"fileName": "src/MorphDeformer.ts",
 							"line": 30,
 							"character": 21,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphDeformer.ts#L30"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphDeformer.ts#L30"
 						}
 					],
 					"extendedTypes": [
@@ -25930,7 +25930,7 @@
 					"fileName": "src/MorphDeformer.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MorphDeformer.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MorphDeformer.ts#L1"
 				}
 			]
 		},
@@ -25967,7 +25967,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 9,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L9"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L9"
 								}
 							],
 							"type": {
@@ -25986,7 +25986,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 8,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L8"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L8"
 								}
 							],
 							"type": {
@@ -26005,7 +26005,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 10,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L10"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L10"
 								}
 							],
 							"type": {
@@ -26029,7 +26029,7 @@
 							"fileName": "src/PbrSurface.ts",
 							"line": 7,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L7"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L7"
 						}
 					]
 				},
@@ -26061,7 +26061,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 31,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L31"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L31"
 								}
 							],
 							"signatures": [
@@ -26110,7 +26110,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -26148,7 +26148,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -26182,7 +26182,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -26216,7 +26216,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -26250,7 +26250,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -26294,7 +26294,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 29,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L29"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L29"
 								}
 							],
 							"type": {
@@ -26343,7 +26343,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 26,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L26"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L26"
 								}
 							],
 							"type": {
@@ -26364,7 +26364,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -26407,7 +26407,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -26450,7 +26450,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -26495,7 +26495,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 41,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L41"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L41"
 								}
 							],
 							"signatures": [
@@ -26563,7 +26563,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -26661,7 +26661,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -26729,7 +26729,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -26833,7 +26833,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -26880,7 +26880,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -26948,7 +26948,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -27016,7 +27016,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -27062,7 +27062,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -27108,7 +27108,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -27186,7 +27186,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -27254,7 +27254,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -27322,7 +27322,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 172,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L172"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L172"
 								}
 							],
 							"signatures": [
@@ -27432,7 +27432,7 @@
 							"fileName": "src/PbrSurface.ts",
 							"line": 24,
 							"character": 22,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L24"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L24"
 						}
 					],
 					"extendedTypes": [
@@ -27481,7 +27481,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L75"
 								}
 							],
 							"signatures": [
@@ -27530,7 +27530,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -27568,7 +27568,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -27602,7 +27602,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -27636,7 +27636,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -27670,7 +27670,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -27714,7 +27714,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 62,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L62"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L62"
 								}
 							],
 							"type": {
@@ -27744,7 +27744,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 64,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L64"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L64"
 								}
 							],
 							"type": {
@@ -27774,7 +27774,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 66,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L66"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L66"
 								}
 							],
 							"type": {
@@ -27804,7 +27804,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 68,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L68"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L68"
 								}
 							],
 							"type": {
@@ -27834,7 +27834,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 29,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L29"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L29"
 								}
 							],
 							"type": {
@@ -27888,7 +27888,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 70,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L70"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L70"
 								}
 							],
 							"type": {
@@ -27918,7 +27918,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 72,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L72"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L72"
 								}
 							],
 							"type": {
@@ -27948,7 +27948,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 59,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L59"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L59"
 								}
 							],
 							"type": {
@@ -27974,7 +27974,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -28017,7 +28017,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -28060,7 +28060,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -28105,7 +28105,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 91,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L91"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L91"
 								}
 							],
 							"signatures": [
@@ -28173,7 +28173,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -28271,7 +28271,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -28339,7 +28339,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -28443,7 +28443,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -28490,7 +28490,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -28558,7 +28558,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -28626,7 +28626,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -28672,7 +28672,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -28718,7 +28718,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -28796,7 +28796,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -28864,7 +28864,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -28932,7 +28932,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 172,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L172"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L172"
 								}
 							],
 							"signatures": [
@@ -29048,7 +29048,7 @@
 							"fileName": "src/PbrSurface.ts",
 							"line": 57,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L57"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L57"
 						}
 					],
 					"extendedTypes": [
@@ -29085,7 +29085,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 127,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L127"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L127"
 								}
 							],
 							"signatures": [
@@ -29134,7 +29134,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -29172,7 +29172,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -29206,7 +29206,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -29240,7 +29240,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -29274,7 +29274,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -29318,7 +29318,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 115,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L115"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L115"
 								}
 							],
 							"type": {
@@ -29348,7 +29348,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 117,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L117"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L117"
 								}
 							],
 							"type": {
@@ -29378,7 +29378,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 123,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L123"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L123"
 								}
 							],
 							"type": {
@@ -29408,7 +29408,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 125,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L125"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L125"
 								}
 							],
 							"type": {
@@ -29438,7 +29438,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 29,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L29"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L29"
 								}
 							],
 							"type": {
@@ -29492,7 +29492,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 119,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L119"
 								}
 							],
 							"type": {
@@ -29522,7 +29522,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 121,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L121"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L121"
 								}
 							],
 							"type": {
@@ -29552,7 +29552,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 112,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L112"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L112"
 								}
 							],
 							"type": {
@@ -29578,7 +29578,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -29621,7 +29621,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -29664,7 +29664,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -29709,7 +29709,7 @@
 									"fileName": "src/PbrSurface.ts",
 									"line": 142,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L142"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L142"
 								}
 							],
 							"signatures": [
@@ -29777,7 +29777,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -29875,7 +29875,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -29943,7 +29943,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -30047,7 +30047,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -30094,7 +30094,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -30162,7 +30162,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -30230,7 +30230,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -30276,7 +30276,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -30322,7 +30322,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -30400,7 +30400,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -30468,7 +30468,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -30536,7 +30536,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 172,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L172"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L172"
 								}
 							],
 							"signatures": [
@@ -30652,7 +30652,7 @@
 							"fileName": "src/PbrSurface.ts",
 							"line": 110,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L110"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L110"
 						}
 					],
 					"extendedTypes": [
@@ -30682,7 +30682,7 @@
 							"fileName": "src/PbrSurface.ts",
 							"line": 14,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L14"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L14"
 						}
 					],
 					"type": {
@@ -30729,7 +30729,7 @@
 					"fileName": "src/PbrSurface.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/PbrSurface.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/PbrSurface.ts#L1"
 				}
 			]
 		},
@@ -30767,7 +30767,7 @@
 									"fileName": "src/ProgramCache.ts",
 									"line": 44,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ProgramCache.ts#L44"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ProgramCache.ts#L44"
 								}
 							],
 							"signatures": [
@@ -30829,7 +30829,7 @@
 									"fileName": "src/ProgramCache.ts",
 									"line": 39,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ProgramCache.ts#L39"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ProgramCache.ts#L39"
 								}
 							],
 							"type": {
@@ -30870,7 +30870,7 @@
 									"fileName": "src/ProgramCache.ts",
 									"line": 36,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ProgramCache.ts#L36"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ProgramCache.ts#L36"
 								}
 							],
 							"type": {
@@ -30891,7 +30891,7 @@
 									"fileName": "src/ProgramCache.ts",
 									"line": 68,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ProgramCache.ts#L68"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ProgramCache.ts#L68"
 								}
 							],
 							"signatures": [
@@ -30951,7 +30951,7 @@
 									"fileName": "src/ProgramCache.ts",
 									"line": 93,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ProgramCache.ts#L93"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ProgramCache.ts#L93"
 								}
 							],
 							"signatures": [
@@ -31012,7 +31012,7 @@
 									"fileName": "src/ProgramCache.ts",
 									"line": 53,
 									"character": 9,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ProgramCache.ts#L53"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ProgramCache.ts#L53"
 								}
 							],
 							"signatures": [
@@ -31090,7 +31090,7 @@
 							"fileName": "src/ProgramCache.ts",
 							"line": 34,
 							"character": 6,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ProgramCache.ts#L34"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ProgramCache.ts#L34"
 						}
 					]
 				}
@@ -31108,7 +31108,7 @@
 					"fileName": "src/ProgramCache.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ProgramCache.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ProgramCache.ts#L1"
 				}
 			]
 		},
@@ -31146,7 +31146,7 @@
 									"fileName": "src/ProgramSource.ts",
 									"line": 29,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ProgramSource.ts#L29"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ProgramSource.ts#L29"
 								}
 							],
 							"signatures": [
@@ -31228,7 +31228,7 @@
 									"fileName": "src/ProgramSource.ts",
 									"line": 14,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ProgramSource.ts#L14"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ProgramSource.ts#L14"
 								}
 							],
 							"type": {
@@ -31262,7 +31262,7 @@
 									"fileName": "src/ProgramSource.ts",
 									"line": 18,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ProgramSource.ts#L18"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ProgramSource.ts#L18"
 								}
 							],
 							"type": {
@@ -31290,7 +31290,7 @@
 									"fileName": "src/ProgramSource.ts",
 									"line": 21,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ProgramSource.ts#L21"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ProgramSource.ts#L21"
 								}
 							],
 							"type": {
@@ -31329,7 +31329,7 @@
 									"fileName": "src/ProgramSource.ts",
 									"line": 23,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ProgramSource.ts#L23"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ProgramSource.ts#L23"
 								}
 							],
 							"type": {
@@ -31359,7 +31359,7 @@
 									"fileName": "src/ProgramSource.ts",
 									"line": 16,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ProgramSource.ts#L16"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ProgramSource.ts#L16"
 								}
 							],
 							"type": {
@@ -31379,7 +31379,7 @@
 									"fileName": "src/ProgramSource.ts",
 									"line": 38,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ProgramSource.ts#L38"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ProgramSource.ts#L38"
 								}
 							],
 							"signatures": [
@@ -31437,7 +31437,7 @@
 									"fileName": "src/ProgramSource.ts",
 									"line": 84,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ProgramSource.ts#L84"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ProgramSource.ts#L84"
 								}
 							],
 							"signatures": [
@@ -31473,7 +31473,7 @@
 									"fileName": "src/ProgramSource.ts",
 									"line": 70,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ProgramSource.ts#L70"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ProgramSource.ts#L70"
 								}
 							],
 							"signatures": [
@@ -31511,7 +31511,7 @@
 									"fileName": "src/ProgramSource.ts",
 									"line": 45,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ProgramSource.ts#L45"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ProgramSource.ts#L45"
 								}
 							],
 							"signatures": [
@@ -31547,7 +31547,7 @@
 									"fileName": "src/ProgramSource.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ProgramSource.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ProgramSource.ts#L56"
 								}
 							],
 							"signatures": [
@@ -31608,7 +31608,7 @@
 							"fileName": "src/ProgramSource.ts",
 							"line": 12,
 							"character": 21,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ProgramSource.ts#L12"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ProgramSource.ts#L12"
 						}
 					]
 				}
@@ -31626,7 +31626,7 @@
 					"fileName": "src/ProgramSource.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ProgramSource.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ProgramSource.ts#L1"
 				}
 			]
 		},
@@ -31664,7 +31664,7 @@
 									"fileName": "src/ShaderPrecision.ts",
 									"line": 21,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ShaderPrecision.ts#L21"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ShaderPrecision.ts#L21"
 								}
 							],
 							"signatures": [
@@ -31736,7 +31736,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -31774,7 +31774,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -31808,7 +31808,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -31842,7 +31842,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -31876,7 +31876,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -31920,7 +31920,7 @@
 									"fileName": "src/ShaderPrecision.ts",
 									"line": 16,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ShaderPrecision.ts#L16"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ShaderPrecision.ts#L16"
 								}
 							],
 							"type": {
@@ -31940,7 +31940,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -31983,7 +31983,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -32026,7 +32026,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -32069,7 +32069,7 @@
 									"fileName": "src/ShaderPrecision.ts",
 									"line": 54,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ShaderPrecision.ts#L54"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ShaderPrecision.ts#L54"
 								}
 							],
 							"signatures": [
@@ -32160,7 +32160,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -32258,7 +32258,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -32326,7 +32326,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -32430,7 +32430,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -32477,7 +32477,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -32545,7 +32545,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -32613,7 +32613,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -32659,7 +32659,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -32705,7 +32705,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -32783,7 +32783,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -32851,7 +32851,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -32919,7 +32919,7 @@
 									"fileName": "src/ShaderPrecision.ts",
 									"line": 34,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ShaderPrecision.ts#L34"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ShaderPrecision.ts#L34"
 								}
 							],
 							"signatures": [
@@ -32977,7 +32977,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 172,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L172"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L172"
 								}
 							],
 							"signatures": [
@@ -33087,7 +33087,7 @@
 							"fileName": "src/ShaderPrecision.ts",
 							"line": 14,
 							"character": 6,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ShaderPrecision.ts#L14"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ShaderPrecision.ts#L14"
 						}
 					],
 					"extendedTypes": [
@@ -33112,7 +33112,7 @@
 					"fileName": "src/ShaderPrecision.ts",
 					"line": 2,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ShaderPrecision.ts#L2"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ShaderPrecision.ts#L2"
 				}
 			]
 		},
@@ -33150,7 +33150,7 @@
 									"fileName": "src/ShaderVersion.ts",
 									"line": 22,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ShaderVersion.ts#L22"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ShaderVersion.ts#L22"
 								}
 							],
 							"signatures": [
@@ -33222,7 +33222,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -33260,7 +33260,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -33294,7 +33294,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -33328,7 +33328,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -33362,7 +33362,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -33406,7 +33406,7 @@
 									"fileName": "src/ShaderVersion.ts",
 									"line": 17,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ShaderVersion.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ShaderVersion.ts#L17"
 								}
 							],
 							"type": {
@@ -33426,7 +33426,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -33469,7 +33469,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -33512,7 +33512,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -33555,7 +33555,7 @@
 									"fileName": "src/ShaderVersion.ts",
 									"line": 65,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ShaderVersion.ts#L65"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ShaderVersion.ts#L65"
 								}
 							],
 							"signatures": [
@@ -33646,7 +33646,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -33744,7 +33744,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -33812,7 +33812,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -33916,7 +33916,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -33963,7 +33963,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -34031,7 +34031,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -34099,7 +34099,7 @@
 									"fileName": "src/ShaderVersion.ts",
 									"line": 45,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ShaderVersion.ts#L45"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ShaderVersion.ts#L45"
 								}
 							],
 							"signatures": [
@@ -34136,7 +34136,7 @@
 									"fileName": "src/ShaderVersion.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ShaderVersion.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ShaderVersion.ts#L75"
 								}
 							],
 							"signatures": [
@@ -34195,7 +34195,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -34241,7 +34241,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -34287,7 +34287,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -34365,7 +34365,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -34433,7 +34433,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -34501,7 +34501,7 @@
 									"fileName": "src/ShaderVersion.ts",
 									"line": 35,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ShaderVersion.ts#L35"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ShaderVersion.ts#L35"
 								}
 							],
 							"signatures": [
@@ -34559,7 +34559,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 172,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L172"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L172"
 								}
 							],
 							"signatures": [
@@ -34671,7 +34671,7 @@
 							"fileName": "src/ShaderVersion.ts",
 							"line": 15,
 							"character": 6,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ShaderVersion.ts#L15"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ShaderVersion.ts#L15"
 						}
 					],
 					"extendedTypes": [
@@ -34701,7 +34701,7 @@
 							"fileName": "src/ShaderVersion.ts",
 							"line": 7,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ShaderVersion.ts#L7"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ShaderVersion.ts#L7"
 						}
 					],
 					"type": {
@@ -34738,7 +34738,7 @@
 					"fileName": "src/ShaderVersion.ts",
 					"line": 2,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ShaderVersion.ts#L2"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ShaderVersion.ts#L2"
 				}
 			]
 		},
@@ -34771,7 +34771,7 @@
 							"fileName": "src/ShadowFilteringEnum.ts",
 							"line": 19,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ShadowFilteringEnum.ts#L19"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ShadowFilteringEnum.ts#L19"
 						}
 					],
 					"type": {
@@ -34811,7 +34811,7 @@
 							"fileName": "src/ShadowFilteringEnum.ts",
 							"line": 4,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ShadowFilteringEnum.ts#L4"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ShadowFilteringEnum.ts#L4"
 						}
 					],
 					"type": {
@@ -34861,7 +34861,7 @@
 					"fileName": "src/ShadowFilteringEnum.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/ShadowFilteringEnum.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/ShadowFilteringEnum.ts#L1"
 				}
 			]
 		},
@@ -34885,7 +34885,7 @@
 							"fileName": "src/SkinCode.ts",
 							"line": 10,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinCode.ts#L10"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinCode.ts#L10"
 						}
 					],
 					"type": {
@@ -34916,7 +34916,7 @@
 							"fileName": "src/SkinCode.ts",
 							"line": 52,
 							"character": 6,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinCode.ts#L52"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinCode.ts#L52"
 						}
 					],
 					"type": {
@@ -34939,7 +34939,7 @@
 											"fileName": "src/SkinCode.ts",
 											"line": 57,
 											"character": 2,
-											"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinCode.ts#L57"
+											"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinCode.ts#L57"
 										}
 									],
 									"signatures": [
@@ -34997,7 +34997,7 @@
 											"fileName": "src/SkinCode.ts",
 											"line": 69,
 											"character": 2,
-											"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinCode.ts#L69"
+											"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinCode.ts#L69"
 										}
 									],
 									"signatures": [
@@ -35037,7 +35037,7 @@
 									"fileName": "src/SkinCode.ts",
 									"line": 52,
 									"character": 17,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinCode.ts#L52"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinCode.ts#L52"
 								}
 							]
 						}
@@ -35059,7 +35059,7 @@
 					"fileName": "src/SkinCode.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinCode.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinCode.ts#L1"
 				}
 			]
 		},
@@ -35105,7 +35105,7 @@
 									"fileName": "src/SkinDeformer.ts",
 									"line": 51,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinDeformer.ts#L51"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinDeformer.ts#L51"
 								}
 							],
 							"signatures": [
@@ -35196,7 +35196,7 @@
 									"fileName": "src/SkinDeformer.ts",
 									"line": 38,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinDeformer.ts#L38"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinDeformer.ts#L38"
 								}
 							],
 							"type": {
@@ -35229,7 +35229,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -35267,7 +35267,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -35301,7 +35301,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -35335,7 +35335,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -35369,7 +35369,7 @@
 									"fileName": "src/SkinDeformer.ts",
 									"line": 45,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinDeformer.ts#L45"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinDeformer.ts#L45"
 								}
 							],
 							"type": {
@@ -35403,7 +35403,7 @@
 									"fileName": "src/SkinDeformer.ts",
 									"line": 43,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinDeformer.ts#L43"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinDeformer.ts#L43"
 								}
 							],
 							"type": {
@@ -35432,7 +35432,7 @@
 									"fileName": "src/SkinDeformer.ts",
 									"line": 40,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinDeformer.ts#L40"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinDeformer.ts#L40"
 								}
 							],
 							"type": {
@@ -35461,7 +35461,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -35495,7 +35495,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -35538,7 +35538,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -35581,7 +35581,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -35624,7 +35624,7 @@
 									"fileName": "src/SkinDeformer.ts",
 									"line": 75,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinDeformer.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinDeformer.ts#L75"
 								}
 							],
 							"getSignature": {
@@ -35663,7 +35663,7 @@
 									"fileName": "src/SkinDeformer.ts",
 									"line": 68,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinDeformer.ts#L68"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinDeformer.ts#L68"
 								}
 							],
 							"getSignature": {
@@ -35699,7 +35699,7 @@
 									"fileName": "src/SkinDeformer.ts",
 									"line": 91,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinDeformer.ts#L91"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinDeformer.ts#L91"
 								}
 							],
 							"signatures": [
@@ -35767,7 +35767,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -35865,7 +35865,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -35933,7 +35933,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -36037,7 +36037,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -36084,7 +36084,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -36152,7 +36152,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -36220,7 +36220,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -36266,7 +36266,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -36312,7 +36312,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -36390,7 +36390,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -36458,7 +36458,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -36526,7 +36526,7 @@
 									"fileName": "src/SkinDeformer.ts",
 									"line": 83,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinDeformer.ts#L83"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinDeformer.ts#L83"
 								}
 							],
 							"signatures": [
@@ -36640,7 +36640,7 @@
 							"fileName": "src/SkinDeformer.ts",
 							"line": 36,
 							"character": 21,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinDeformer.ts#L36"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinDeformer.ts#L36"
 						}
 					],
 					"extendedTypes": [
@@ -36681,7 +36681,7 @@
 							"fileName": "src/SkinDeformer.ts",
 							"line": 19,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinDeformer.ts#L19"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinDeformer.ts#L19"
 						}
 					],
 					"type": {
@@ -36712,7 +36712,7 @@
 											"fileName": "src/SkinDeformer.ts",
 											"line": 23,
 											"character": 2,
-											"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinDeformer.ts#L23"
+											"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinDeformer.ts#L23"
 										}
 									],
 									"type": {
@@ -36755,7 +36755,7 @@
 											"fileName": "src/SkinDeformer.ts",
 											"line": 25,
 											"character": 2,
-											"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinDeformer.ts#L25"
+											"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinDeformer.ts#L25"
 										}
 									],
 									"type": {
@@ -36799,7 +36799,7 @@
 											"fileName": "src/SkinDeformer.ts",
 											"line": 21,
 											"character": 2,
-											"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinDeformer.ts#L21"
+											"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinDeformer.ts#L21"
 										}
 									],
 									"type": {
@@ -36823,7 +36823,7 @@
 									"fileName": "src/SkinDeformer.ts",
 									"line": 19,
 									"character": 31,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinDeformer.ts#L19"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinDeformer.ts#L19"
 								}
 							]
 						}
@@ -36849,7 +36849,7 @@
 					"fileName": "src/SkinDeformer.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/SkinDeformer.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/SkinDeformer.ts#L1"
 				}
 			]
 		},
@@ -36886,7 +36886,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 212,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L212"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L212"
 								}
 							],
 							"signatures": [
@@ -36957,7 +36957,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 28,
 									"character": 24,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L28"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L28"
 								}
 							],
 							"type": {
@@ -36990,7 +36990,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 41,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L41"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L41"
 								}
 							],
 							"type": {
@@ -37023,7 +37023,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 45,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L45"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L45"
 								}
 							],
 							"type": {
@@ -37056,7 +37056,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 43,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L43"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L43"
 								}
 							],
 							"type": {
@@ -37089,7 +37089,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 67,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L67"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L67"
 								}
 							],
 							"type": {
@@ -37122,7 +37122,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 72,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L72"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L72"
 								}
 							],
 							"type": {
@@ -37161,7 +37161,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 47,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L47"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L47"
 								}
 							],
 							"type": {
@@ -37194,7 +37194,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 49,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L49"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L49"
 								}
 							],
 							"type": {
@@ -37227,7 +37227,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 69,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L69"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L69"
 								}
 							],
 							"type": {
@@ -37262,7 +37262,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 21,
 									"character": 13,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L21"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L21"
 								}
 							],
 							"type": {
@@ -37297,7 +37297,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 79,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L79"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L79"
 								}
 							],
 							"type": {
@@ -37336,7 +37336,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 64,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L64"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L64"
 								}
 							],
 							"type": {
@@ -37377,7 +37377,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 62,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L62"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L62"
 								}
 							],
 							"type": {
@@ -37410,7 +37410,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 23,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L23"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L23"
 								}
 							],
 							"type": {
@@ -37444,7 +37444,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 18,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L18"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L18"
 								}
 							],
 							"type": {
@@ -37477,7 +37477,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 16,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L16"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L16"
 								}
 							],
 							"type": {
@@ -37510,7 +37510,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 51,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L51"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L51"
 								}
 							],
 							"type": {
@@ -37543,7 +37543,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 53,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L53"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L53"
 								}
 							],
 							"type": {
@@ -37576,7 +37576,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 55,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L55"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L55"
 								}
 							],
 							"type": {
@@ -37609,7 +37609,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 57,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L57"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L57"
 								}
 							],
 							"type": {
@@ -37642,7 +37642,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 81,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L81"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L81"
 								}
 							],
 							"type": {
@@ -37681,7 +37681,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 37,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L37"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L37"
 								}
 							],
 							"type": {
@@ -37714,7 +37714,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 39,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L39"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L39"
 								}
 							],
 							"type": {
@@ -37755,7 +37755,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 207,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L207"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L207"
 								}
 							],
 							"type": {
@@ -37788,7 +37788,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 35,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L35"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L35"
 								}
 							],
 							"type": {
@@ -37813,7 +37813,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 157,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L157"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L157"
 								}
 							],
 							"signatures": [
@@ -37932,7 +37932,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 152,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L152"
 								}
 							],
 							"signatures": [
@@ -38000,7 +38000,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 140,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L140"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L140"
 								}
 							],
 							"signatures": [
@@ -38109,7 +38109,7 @@
 							"fileName": "src/StandardPass.ts",
 							"line": 205,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L205"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L205"
 						}
 					],
 					"extendedTypes": [
@@ -38153,7 +38153,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 91,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L91"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L91"
 								}
 							],
 							"signatures": [
@@ -38258,7 +38258,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 28,
 									"character": 24,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L28"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L28"
 								}
 							],
 							"type": {
@@ -38291,7 +38291,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 41,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L41"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L41"
 								}
 							],
 							"type": {
@@ -38319,7 +38319,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 45,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L45"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L45"
 								}
 							],
 							"type": {
@@ -38347,7 +38347,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 43,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L43"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L43"
 								}
 							],
 							"type": {
@@ -38375,7 +38375,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 67,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L67"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L67"
 								}
 							],
 							"type": {
@@ -38403,7 +38403,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 72,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L72"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L72"
 								}
 							],
 							"type": {
@@ -38437,7 +38437,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 47,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L47"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L47"
 								}
 							],
 							"type": {
@@ -38465,7 +38465,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 49,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L49"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L49"
 								}
 							],
 							"type": {
@@ -38493,7 +38493,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 69,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L69"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L69"
 								}
 							],
 							"type": {
@@ -38523,7 +38523,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 21,
 									"character": 13,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L21"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L21"
 								}
 							],
 							"type": {
@@ -38558,7 +38558,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 79,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L79"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L79"
 								}
 							],
 							"type": {
@@ -38592,7 +38592,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 64,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L64"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L64"
 								}
 							],
 							"type": {
@@ -38628,7 +38628,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 62,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L62"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L62"
 								}
 							],
 							"type": {
@@ -38656,7 +38656,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 23,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L23"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L23"
 								}
 							],
 							"type": {
@@ -38690,7 +38690,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 18,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L18"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L18"
 								}
 							],
 							"type": {
@@ -38723,7 +38723,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 16,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L16"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L16"
 								}
 							],
 							"type": {
@@ -38756,7 +38756,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 51,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L51"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L51"
 								}
 							],
 							"type": {
@@ -38784,7 +38784,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 53,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L53"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L53"
 								}
 							],
 							"type": {
@@ -38812,7 +38812,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 55,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L55"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L55"
 								}
 							],
 							"type": {
@@ -38840,7 +38840,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 57,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L57"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L57"
 								}
 							],
 							"type": {
@@ -38868,7 +38868,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 81,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L81"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L81"
 								}
 							],
 							"type": {
@@ -38902,7 +38902,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 37,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L37"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L37"
 								}
 							],
 							"type": {
@@ -38930,7 +38930,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 39,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L39"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L39"
 								}
 							],
 							"type": {
@@ -38966,7 +38966,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 83,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L83"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L83"
 								}
 							],
 							"type": {
@@ -38994,7 +38994,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 35,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L35"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L35"
 								}
 							],
 							"type": {
@@ -39014,7 +39014,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 157,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L157"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L157"
 								}
 							],
 							"signatures": [
@@ -39133,7 +39133,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 152,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L152"
 								}
 							],
 							"signatures": [
@@ -39191,7 +39191,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 140,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L140"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L140"
 								}
 							],
 							"signatures": [
@@ -39290,7 +39290,7 @@
 							"fileName": "src/StandardPass.ts",
 							"line": 32,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L32"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L32"
 						}
 					],
 					"typeParameters": [
@@ -39366,7 +39366,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 192,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L192"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L192"
 								}
 							],
 							"signatures": [
@@ -39437,7 +39437,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 28,
 									"character": 24,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L28"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L28"
 								}
 							],
 							"type": {
@@ -39470,7 +39470,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 41,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L41"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L41"
 								}
 							],
 							"type": {
@@ -39503,7 +39503,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 45,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L45"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L45"
 								}
 							],
 							"type": {
@@ -39536,7 +39536,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 43,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L43"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L43"
 								}
 							],
 							"type": {
@@ -39569,7 +39569,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 67,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L67"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L67"
 								}
 							],
 							"type": {
@@ -39602,7 +39602,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 72,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L72"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L72"
 								}
 							],
 							"type": {
@@ -39641,7 +39641,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 47,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L47"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L47"
 								}
 							],
 							"type": {
@@ -39674,7 +39674,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 49,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L49"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L49"
 								}
 							],
 							"type": {
@@ -39707,7 +39707,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 69,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L69"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L69"
 								}
 							],
 							"type": {
@@ -39742,7 +39742,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 21,
 									"character": 13,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L21"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L21"
 								}
 							],
 							"type": {
@@ -39777,7 +39777,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 79,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L79"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L79"
 								}
 							],
 							"type": {
@@ -39816,7 +39816,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 64,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L64"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L64"
 								}
 							],
 							"type": {
@@ -39857,7 +39857,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 62,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L62"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L62"
 								}
 							],
 							"type": {
@@ -39890,7 +39890,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 23,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L23"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L23"
 								}
 							],
 							"type": {
@@ -39924,7 +39924,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 18,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L18"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L18"
 								}
 							],
 							"type": {
@@ -39957,7 +39957,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 16,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L16"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L16"
 								}
 							],
 							"type": {
@@ -39990,7 +39990,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 51,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L51"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L51"
 								}
 							],
 							"type": {
@@ -40023,7 +40023,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 53,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L53"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L53"
 								}
 							],
 							"type": {
@@ -40056,7 +40056,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 55,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L55"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L55"
 								}
 							],
 							"type": {
@@ -40089,7 +40089,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 57,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L57"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L57"
 								}
 							],
 							"type": {
@@ -40122,7 +40122,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 81,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L81"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L81"
 								}
 							],
 							"type": {
@@ -40161,7 +40161,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 37,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L37"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L37"
 								}
 							],
 							"type": {
@@ -40194,7 +40194,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 39,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L39"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L39"
 								}
 							],
 							"type": {
@@ -40235,7 +40235,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 187,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L187"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L187"
 								}
 							],
 							"type": {
@@ -40268,7 +40268,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 35,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L35"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L35"
 								}
 							],
 							"type": {
@@ -40293,7 +40293,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 157,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L157"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L157"
 								}
 							],
 							"signatures": [
@@ -40412,7 +40412,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 152,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L152"
 								}
 							],
 							"signatures": [
@@ -40480,7 +40480,7 @@
 									"fileName": "src/StandardPass.ts",
 									"line": 140,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L140"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L140"
 								}
 							],
 							"signatures": [
@@ -40589,7 +40589,7 @@
 							"fileName": "src/StandardPass.ts",
 							"line": 185,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L185"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L185"
 						}
 					],
 					"extendedTypes": [
@@ -40623,7 +40623,7 @@
 					"fileName": "src/StandardPass.ts",
 					"line": 2,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/StandardPass.ts#L2"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/StandardPass.ts#L2"
 				}
 			]
 		},
@@ -40654,7 +40654,7 @@
 							"fileName": "src/Swizzle.ts",
 							"line": 2,
 							"character": 5,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Swizzle.ts#L2"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Swizzle.ts#L2"
 						}
 					],
 					"type": {
@@ -43397,7 +43397,7 @@
 					"fileName": "src/Swizzle.ts",
 					"line": 2,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Swizzle.ts#L2"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Swizzle.ts#L2"
 				}
 			]
 		},
@@ -43434,7 +43434,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 249,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L249"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L249"
 								}
 							],
 							"signatures": [
@@ -43507,7 +43507,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -43545,7 +43545,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -43579,7 +43579,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -43613,7 +43613,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -43647,7 +43647,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -43692,7 +43692,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 237,
 									"character": 19,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L237"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L237"
 								}
 							],
 							"type": {
@@ -43723,7 +43723,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 241,
 									"character": 19,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L241"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L241"
 								}
 							],
 							"type": {
@@ -43753,7 +43753,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 193,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L193"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L193"
 								}
 							],
 							"type": {
@@ -43789,7 +43789,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 235,
 									"character": 19,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L235"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L235"
 								}
 							],
 							"type": {
@@ -43820,7 +43820,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 239,
 									"character": 19,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L239"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L239"
 								}
 							],
 							"type": {
@@ -43850,7 +43850,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 198,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L198"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L198"
 								}
 							],
 							"type": {
@@ -43885,7 +43885,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 196,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L196"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L196"
 								}
 							],
 							"type": {
@@ -43920,7 +43920,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 244,
 									"character": 17,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L244"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L244"
 								}
 							],
 							"type": {
@@ -43940,7 +43940,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -43983,7 +43983,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -44026,7 +44026,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -44069,7 +44069,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 219,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L219"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L219"
 								}
 							],
 							"signatures": [
@@ -44137,7 +44137,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -44235,7 +44235,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -44303,7 +44303,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -44407,7 +44407,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -44454,7 +44454,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -44522,7 +44522,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -44590,7 +44590,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 267,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L267"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L267"
 								}
 							],
 							"signatures": [
@@ -44636,7 +44636,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -44682,7 +44682,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -44728,7 +44728,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -44806,7 +44806,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -44874,7 +44874,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -44942,7 +44942,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 287,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L287"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L287"
 								}
 							],
 							"signatures": [
@@ -45000,7 +45000,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 298,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L298"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L298"
 								}
 							],
 							"signatures": [
@@ -45080,7 +45080,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 309,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L309"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L309"
 								}
 							],
 							"signatures": [
@@ -45139,7 +45139,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 172,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L172"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L172"
 								}
 							],
 							"signatures": [
@@ -45208,7 +45208,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 276,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L276"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L276"
 								}
 							],
 							"signatures": [
@@ -45285,7 +45285,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 321,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L321"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L321"
 								}
 							],
 							"signatures": [
@@ -45321,7 +45321,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 263,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L263"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L263"
 								}
 							],
 							"signatures": [
@@ -45369,7 +45369,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 158,
 									"character": 9,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L158"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L158"
 								}
 							],
 							"signatures": [
@@ -45441,7 +45441,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 176,
 									"character": 9,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L176"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L176"
 								}
 							],
 							"signatures": [
@@ -45536,7 +45536,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 167,
 									"character": 9,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L167"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L167"
 								}
 							],
 							"signatures": [
@@ -45632,7 +45632,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 188,
 									"character": 9,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L188"
 								}
 							],
 							"signatures": [
@@ -45760,7 +45760,7 @@
 							"fileName": "src/TexCoord.ts",
 							"line": 233,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L233"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L233"
 						}
 					],
 					"extendedTypes": [
@@ -45797,7 +45797,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 351,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L351"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L351"
 								}
 							],
 							"signatures": [
@@ -45891,7 +45891,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -45929,7 +45929,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -45963,7 +45963,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -45997,7 +45997,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -46031,7 +46031,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -46076,7 +46076,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 345,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L345"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L345"
 								}
 							],
 							"type": {
@@ -46107,7 +46107,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 340,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L340"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L340"
 								}
 							],
 							"type": {
@@ -46137,7 +46137,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 193,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L193"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L193"
 								}
 							],
 							"type": {
@@ -46173,7 +46173,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 343,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L343"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L343"
 								}
 							],
 							"type": {
@@ -46204,7 +46204,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 338,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L338"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L338"
 								}
 							],
 							"type": {
@@ -46234,7 +46234,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 198,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L198"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L198"
 								}
 							],
 							"type": {
@@ -46269,7 +46269,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 196,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L196"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L196"
 								}
 							],
 							"type": {
@@ -46293,7 +46293,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -46336,7 +46336,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -46379,7 +46379,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -46422,7 +46422,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 219,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L219"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L219"
 								}
 							],
 							"signatures": [
@@ -46490,7 +46490,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -46588,7 +46588,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -46656,7 +46656,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -46760,7 +46760,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -46807,7 +46807,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -46875,7 +46875,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -46943,7 +46943,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 379,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L379"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L379"
 								}
 							],
 							"signatures": [
@@ -46989,7 +46989,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -47035,7 +47035,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -47081,7 +47081,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -47159,7 +47159,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -47227,7 +47227,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -47295,7 +47295,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 172,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L172"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L172"
 								}
 							],
 							"signatures": [
@@ -47364,7 +47364,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 374,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L374"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L374"
 								}
 							],
 							"signatures": [
@@ -47412,7 +47412,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 158,
 									"character": 9,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L158"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L158"
 								}
 							],
 							"signatures": [
@@ -47484,7 +47484,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 176,
 									"character": 9,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L176"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L176"
 								}
 							],
 							"signatures": [
@@ -47579,7 +47579,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 167,
 									"character": 9,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L167"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L167"
 								}
 							],
 							"signatures": [
@@ -47675,7 +47675,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 188,
 									"character": 9,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L188"
 								}
 							],
 							"signatures": [
@@ -47797,7 +47797,7 @@
 							"fileName": "src/TexCoord.ts",
 							"line": 335,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L335"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L335"
 						}
 					],
 					"extendedTypes": [
@@ -47837,7 +47837,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L204"
 								}
 							],
 							"signatures": [
@@ -47929,7 +47929,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -47967,7 +47967,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -48001,7 +48001,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -48035,7 +48035,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -48069,7 +48069,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -48113,7 +48113,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 193,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L193"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L193"
 								}
 							],
 							"type": {
@@ -48143,7 +48143,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 198,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L198"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L198"
 								}
 							],
 							"type": {
@@ -48173,7 +48173,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 196,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L196"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L196"
 								}
 							],
 							"type": {
@@ -48192,7 +48192,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -48235,7 +48235,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -48278,7 +48278,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -48321,7 +48321,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 219,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L219"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L219"
 								}
 							],
 							"signatures": [
@@ -48389,7 +48389,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -48487,7 +48487,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -48555,7 +48555,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -48659,7 +48659,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -48706,7 +48706,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -48774,7 +48774,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -48844,7 +48844,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 213,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L213"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L213"
 								}
 							],
 							"signatures": [
@@ -48880,7 +48880,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -48926,7 +48926,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -48972,7 +48972,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -49050,7 +49050,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -49118,7 +49118,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -49186,7 +49186,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 172,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L172"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L172"
 								}
 							],
 							"signatures": [
@@ -49257,7 +49257,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 211,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L211"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L211"
 								}
 							],
 							"signatures": [
@@ -49295,7 +49295,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 158,
 									"character": 9,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L158"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L158"
 								}
 							],
 							"signatures": [
@@ -49357,7 +49357,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 176,
 									"character": 9,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L176"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L176"
 								}
 							],
 							"signatures": [
@@ -49442,7 +49442,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 167,
 									"character": 9,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L167"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L167"
 								}
 							],
 							"signatures": [
@@ -49528,7 +49528,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 188,
 									"character": 9,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L188"
 								}
 							],
 							"signatures": [
@@ -49636,7 +49636,7 @@
 							"fileName": "src/TexCoord.ts",
 							"line": 153,
 							"character": 15,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L153"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L153"
 						}
 					],
 					"extendedTypes": [
@@ -49716,7 +49716,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 101,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L101"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L101"
 								}
 							],
 							"type": {
@@ -49748,7 +49748,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 108,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L108"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L108"
 								}
 							],
 							"type": {
@@ -49780,7 +49780,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 106,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L106"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L106"
 								}
 							],
 							"type": {
@@ -49812,7 +49812,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 104,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L104"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L104"
 								}
 							],
 							"type": {
@@ -49834,7 +49834,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 128,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L128"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L128"
 								}
 							],
 							"signatures": [
@@ -49872,7 +49872,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 116,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L116"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L116"
 								}
 							],
 							"signatures": [
@@ -49931,7 +49931,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 141,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L141"
 								}
 							],
 							"signatures": [
@@ -49987,7 +49987,7 @@
 							"fileName": "src/TexCoord.ts",
 							"line": 97,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L97"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L97"
 						}
 					]
 				},
@@ -50010,7 +50010,7 @@
 							"fileName": "src/TexCoord.ts",
 							"line": 47,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L47"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L47"
 						}
 					],
 					"type": {
@@ -50043,7 +50043,7 @@
 											"fileName": "src/TexCoord.ts",
 											"line": 51,
 											"character": 2,
-											"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L51"
+											"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L51"
 										}
 									],
 									"type": {
@@ -50072,7 +50072,7 @@
 											"fileName": "src/TexCoord.ts",
 											"line": 53,
 											"character": 2,
-											"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L53"
+											"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L53"
 										}
 									],
 									"type": {
@@ -50101,7 +50101,7 @@
 											"fileName": "src/TexCoord.ts",
 											"line": 49,
 											"character": 2,
-											"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L49"
+											"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L49"
 										}
 									],
 									"type": {
@@ -50134,7 +50134,7 @@
 									"fileName": "src/TexCoord.ts",
 									"line": 47,
 									"character": 22,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L47"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L47"
 								}
 							]
 						}
@@ -50163,7 +50163,7 @@
 					"fileName": "src/TexCoord.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/TexCoord.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/TexCoord.ts#L1"
 				}
 			]
 		},
@@ -50201,7 +50201,7 @@
 									"fileName": "src/UnlitPass.ts",
 									"line": 61,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/UnlitPass.ts#L61"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/UnlitPass.ts#L61"
 								}
 							],
 							"signatures": [
@@ -50272,7 +50272,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 28,
 									"character": 24,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L28"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L28"
 								}
 							],
 							"type": {
@@ -50305,7 +50305,7 @@
 									"fileName": "src/UnlitPass.ts",
 									"line": 44,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/UnlitPass.ts#L44"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/UnlitPass.ts#L44"
 								}
 							],
 							"type": {
@@ -50333,7 +50333,7 @@
 									"fileName": "src/UnlitPass.ts",
 									"line": 48,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/UnlitPass.ts#L48"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/UnlitPass.ts#L48"
 								}
 							],
 							"type": {
@@ -50361,7 +50361,7 @@
 									"fileName": "src/UnlitPass.ts",
 									"line": 46,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/UnlitPass.ts#L46"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/UnlitPass.ts#L46"
 								}
 							],
 							"type": {
@@ -50389,7 +50389,7 @@
 									"fileName": "src/UnlitPass.ts",
 									"line": 51,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/UnlitPass.ts#L51"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/UnlitPass.ts#L51"
 								}
 							],
 							"type": {
@@ -50417,7 +50417,7 @@
 									"fileName": "src/UnlitPass.ts",
 									"line": 40,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/UnlitPass.ts#L40"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/UnlitPass.ts#L40"
 								}
 							],
 							"type": {
@@ -50445,7 +50445,7 @@
 									"fileName": "src/UnlitPass.ts",
 									"line": 42,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/UnlitPass.ts#L42"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/UnlitPass.ts#L42"
 								}
 							],
 							"type": {
@@ -50473,7 +50473,7 @@
 									"fileName": "src/UnlitPass.ts",
 									"line": 54,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/UnlitPass.ts#L54"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/UnlitPass.ts#L54"
 								}
 							],
 							"type": {
@@ -50509,7 +50509,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 21,
 									"character": 13,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L21"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L21"
 								}
 							],
 							"type": {
@@ -50544,7 +50544,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 23,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L23"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L23"
 								}
 							],
 							"type": {
@@ -50578,7 +50578,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 18,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L18"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L18"
 								}
 							],
 							"type": {
@@ -50611,7 +50611,7 @@
 									"fileName": "src/MaterialPass.ts",
 									"line": 16,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/MaterialPass.ts#L16"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/MaterialPass.ts#L16"
 								}
 							],
 							"type": {
@@ -50644,7 +50644,7 @@
 									"fileName": "src/UnlitPass.ts",
 									"line": 36,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/UnlitPass.ts#L36"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/UnlitPass.ts#L36"
 								}
 							],
 							"type": {
@@ -50672,7 +50672,7 @@
 									"fileName": "src/UnlitPass.ts",
 									"line": 38,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/UnlitPass.ts#L38"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/UnlitPass.ts#L38"
 								}
 							],
 							"type": {
@@ -50706,7 +50706,7 @@
 									"fileName": "src/UnlitPass.ts",
 									"line": 34,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/UnlitPass.ts#L34"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/UnlitPass.ts#L34"
 								}
 							],
 							"type": {
@@ -50726,7 +50726,7 @@
 									"fileName": "src/UnlitPass.ts",
 									"line": 100,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/UnlitPass.ts#L100"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/UnlitPass.ts#L100"
 								}
 							],
 							"signatures": [
@@ -50845,7 +50845,7 @@
 									"fileName": "src/UnlitPass.ts",
 									"line": 97,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/UnlitPass.ts#L97"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/UnlitPass.ts#L97"
 								}
 							],
 							"signatures": [
@@ -50933,7 +50933,7 @@
 							"fileName": "src/UnlitPass.ts",
 							"line": 31,
 							"character": 21,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/UnlitPass.ts#L31"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/UnlitPass.ts#L31"
 						}
 					],
 					"extendedTypes": [
@@ -50958,7 +50958,7 @@
 					"fileName": "src/UnlitPass.ts",
 					"line": 4,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/UnlitPass.ts#L4"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/UnlitPass.ts#L4"
 				}
 			]
 		},
@@ -50988,7 +50988,7 @@
 									"fileName": "src/glsl-module.d.ts",
 									"line": 10,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/glsl-module.d.ts#L10"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/glsl-module.d.ts#L10"
 								}
 							],
 							"signatures": [
@@ -51034,7 +51034,7 @@
 							"fileName": "src/glsl-module.d.ts",
 							"line": 9,
 							"character": 0,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/glsl-module.d.ts#L9"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/glsl-module.d.ts#L9"
 						}
 					]
 				},
@@ -51057,7 +51057,7 @@
 									"fileName": "src/glsl-module.d.ts",
 									"line": 2,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/glsl-module.d.ts#L2"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/glsl-module.d.ts#L2"
 								}
 							],
 							"signatures": [
@@ -51103,7 +51103,7 @@
 							"fileName": "src/glsl-module.d.ts",
 							"line": 1,
 							"character": 0,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/glsl-module.d.ts#L1"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/glsl-module.d.ts#L1"
 						}
 					]
 				},
@@ -51126,7 +51126,7 @@
 									"fileName": "src/glsl-module.d.ts",
 									"line": 6,
 									"character": 4,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/glsl-module.d.ts#L6"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/glsl-module.d.ts#L6"
 								}
 							],
 							"signatures": [
@@ -51172,7 +51172,7 @@
 							"fileName": "src/glsl-module.d.ts",
 							"line": 5,
 							"character": 0,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/glsl-module.d.ts#L5"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/glsl-module.d.ts#L5"
 						}
 					]
 				}
@@ -51206,7 +51206,7 @@
 							"fileName": "src/interfaces/GlslCode.ts",
 							"line": 2,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/GlslCode.ts#L2"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/GlslCode.ts#L2"
 						}
 					],
 					"type": {
@@ -51222,7 +51222,7 @@
 									"fileName": "src/interfaces/GlslCode.ts",
 									"line": 2,
 									"character": 23,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/GlslCode.ts#L2"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/GlslCode.ts#L2"
 								}
 							],
 							"signatures": [
@@ -51276,7 +51276,7 @@
 					"fileName": "src/interfaces/GlslCode.ts",
 					"line": 2,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/GlslCode.ts#L2"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/GlslCode.ts#L2"
 				}
 			]
 		},
@@ -51306,7 +51306,7 @@
 							"fileName": "src/interfaces/GlslPrecision.ts",
 							"line": 2,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/GlslPrecision.ts#L2"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/GlslPrecision.ts#L2"
 						}
 					],
 					"type": {
@@ -51341,7 +51341,7 @@
 					"fileName": "src/interfaces/GlslPrecision.ts",
 					"line": 2,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/GlslPrecision.ts#L2"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/GlslPrecision.ts#L2"
 				}
 			]
 		},
@@ -51379,7 +51379,7 @@
 									"fileName": "src/interfaces/ILightModel.ts",
 									"line": 25,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/ILightModel.ts#L25"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/ILightModel.ts#L25"
 								}
 							],
 							"signatures": [
@@ -51437,7 +51437,7 @@
 									"fileName": "src/interfaces/ILightModel.ts",
 									"line": 40,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/ILightModel.ts#L40"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/ILightModel.ts#L40"
 								}
 							],
 							"signatures": [
@@ -51477,7 +51477,7 @@
 									"fileName": "src/interfaces/ILightModel.ts",
 									"line": 19,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/ILightModel.ts#L19"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/ILightModel.ts#L19"
 								}
 							],
 							"signatures": [
@@ -51514,7 +51514,7 @@
 									"fileName": "src/interfaces/ILightModel.ts",
 									"line": 36,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/ILightModel.ts#L36"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/ILightModel.ts#L36"
 								}
 							],
 							"signatures": [
@@ -51573,7 +51573,7 @@
 									"fileName": "src/interfaces/ILightModel.ts",
 									"line": 30,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/ILightModel.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/ILightModel.ts#L30"
 								}
 							],
 							"signatures": [
@@ -51631,7 +51631,7 @@
 									"fileName": "src/interfaces/ILightModel.ts",
 									"line": 15,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/ILightModel.ts#L15"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/ILightModel.ts#L15"
 								}
 							],
 							"signatures": [
@@ -51697,7 +51697,7 @@
 							"fileName": "src/interfaces/ILightModel.ts",
 							"line": 10,
 							"character": 25,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/ILightModel.ts#L10"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/ILightModel.ts#L10"
 						}
 					],
 					"implementedBy": [
@@ -51742,7 +51742,7 @@
 									"fileName": "src/interfaces/ILightModel.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/ILightModel.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/ILightModel.ts#L56"
 								}
 							],
 							"type": {
@@ -51770,7 +51770,7 @@
 									"fileName": "src/interfaces/ILightModel.ts",
 									"line": 49,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/ILightModel.ts#L49"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/ILightModel.ts#L49"
 								}
 							],
 							"type": {
@@ -51798,7 +51798,7 @@
 									"fileName": "src/interfaces/ILightModel.ts",
 									"line": 72,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/ILightModel.ts#L72"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/ILightModel.ts#L72"
 								}
 							],
 							"type": {
@@ -51826,7 +51826,7 @@
 									"fileName": "src/interfaces/ILightModel.ts",
 									"line": 70,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/ILightModel.ts#L70"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/ILightModel.ts#L70"
 								}
 							],
 							"type": {
@@ -51854,7 +51854,7 @@
 									"fileName": "src/interfaces/ILightModel.ts",
 									"line": 60,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/ILightModel.ts#L60"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/ILightModel.ts#L60"
 								}
 							],
 							"type": {
@@ -51882,7 +51882,7 @@
 									"fileName": "src/interfaces/ILightModel.ts",
 									"line": 53,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/ILightModel.ts#L53"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/ILightModel.ts#L53"
 								}
 							],
 							"type": {
@@ -51910,7 +51910,7 @@
 									"fileName": "src/interfaces/ILightModel.ts",
 									"line": 67,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/ILightModel.ts#L67"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/ILightModel.ts#L67"
 								}
 							],
 							"type": {
@@ -51938,7 +51938,7 @@
 									"fileName": "src/interfaces/ILightModel.ts",
 									"line": 65,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/ILightModel.ts#L65"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/ILightModel.ts#L65"
 								}
 							],
 							"type": {
@@ -51966,7 +51966,7 @@
 									"fileName": "src/interfaces/ILightModel.ts",
 									"line": 63,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/ILightModel.ts#L63"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/ILightModel.ts#L63"
 								}
 							],
 							"type": {
@@ -51994,7 +51994,7 @@
 									"fileName": "src/interfaces/ILightModel.ts",
 									"line": 58,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/ILightModel.ts#L58"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/ILightModel.ts#L58"
 								}
 							],
 							"type": {
@@ -52022,7 +52022,7 @@
 									"fileName": "src/interfaces/ILightModel.ts",
 									"line": 51,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/ILightModel.ts#L51"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/ILightModel.ts#L51"
 								}
 							],
 							"type": {
@@ -52055,7 +52055,7 @@
 							"fileName": "src/interfaces/ILightModel.ts",
 							"line": 47,
 							"character": 17,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/ILightModel.ts#L47"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/ILightModel.ts#L47"
 						}
 					]
 				}
@@ -52074,7 +52074,7 @@
 					"fileName": "src/interfaces/ILightModel.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/ILightModel.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/ILightModel.ts#L1"
 				}
 			]
 		},
@@ -52089,7 +52089,7 @@
 					"fileName": "src/interfaces/IMaterial.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/IMaterial.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/IMaterial.ts#L1"
 				}
 			]
 		},
@@ -52135,7 +52135,7 @@
 									"fileName": "src/interfaces/IProgramSource.ts",
 									"line": 18,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/IProgramSource.ts#L18"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/IProgramSource.ts#L18"
 								}
 							],
 							"type": {
@@ -52163,7 +52163,7 @@
 									"fileName": "src/interfaces/IProgramSource.ts",
 									"line": 20,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/IProgramSource.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/IProgramSource.ts#L20"
 								}
 							],
 							"type": {
@@ -52187,7 +52187,7 @@
 							"fileName": "src/interfaces/IProgramSource.ts",
 							"line": 16,
 							"character": 25,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/IProgramSource.ts#L16"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/IProgramSource.ts#L16"
 						}
 					]
 				},
@@ -52210,7 +52210,7 @@
 							"fileName": "src/interfaces/IProgramSource.ts",
 							"line": 4,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/IProgramSource.ts#L4"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/IProgramSource.ts#L4"
 						}
 					],
 					"type": {
@@ -52241,7 +52241,7 @@
 											"fileName": "src/interfaces/IProgramSource.ts",
 											"line": 8,
 											"character": 2,
-											"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/IProgramSource.ts#L8"
+											"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/IProgramSource.ts#L8"
 										}
 									],
 									"type": {
@@ -52268,7 +52268,7 @@
 											"fileName": "src/interfaces/IProgramSource.ts",
 											"line": 10,
 											"character": 2,
-											"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/IProgramSource.ts#L10"
+											"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/IProgramSource.ts#L10"
 										}
 									],
 									"type": {
@@ -52295,7 +52295,7 @@
 											"fileName": "src/interfaces/IProgramSource.ts",
 											"line": 6,
 											"character": 2,
-											"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/IProgramSource.ts#L6"
+											"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/IProgramSource.ts#L6"
 										}
 									],
 									"type": {
@@ -52319,7 +52319,7 @@
 									"fileName": "src/interfaces/IProgramSource.ts",
 									"line": 4,
 									"character": 27,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/IProgramSource.ts#L4"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/IProgramSource.ts#L4"
 								}
 							]
 						}
@@ -52345,7 +52345,7 @@
 					"fileName": "src/interfaces/IProgramSource.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/interfaces/IProgramSource.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/interfaces/IProgramSource.ts#L1"
 				}
 			]
 		},
@@ -52385,7 +52385,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 34,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L34"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L34"
 								}
 							],
 							"signatures": [
@@ -52517,7 +52517,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -52555,7 +52555,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -52589,7 +52589,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -52623,7 +52623,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -52657,7 +52657,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -52706,7 +52706,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 26,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L26"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L26"
 								}
 							],
 							"type": {
@@ -52734,7 +52734,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 19,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L19"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L19"
 								}
 							],
 							"type": {
@@ -52765,7 +52765,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 24,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L24"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L24"
 								}
 							],
 							"type": {
@@ -52793,7 +52793,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 21,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L21"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L21"
 								}
 							],
 							"type": {
@@ -52826,7 +52826,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 16,
 									"character": 20,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L16"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L16"
 								}
 							],
 							"type": {
@@ -52846,7 +52846,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -52889,7 +52889,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -52932,7 +52932,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -52975,7 +52975,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 73,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L73"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L73"
 								}
 							],
 							"signatures": [
@@ -53043,7 +53043,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -53141,7 +53141,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 48,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L48"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L48"
 								}
 							],
 							"signatures": [
@@ -53199,7 +53199,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -53267,7 +53267,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -53371,7 +53371,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -53418,7 +53418,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -53486,7 +53486,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -53556,7 +53556,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 96,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L96"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L96"
 								}
 							],
 							"signatures": [
@@ -53652,7 +53652,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -53698,7 +53698,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -53746,7 +53746,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 103,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L103"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L103"
 								}
 							],
 							"signatures": [
@@ -53825,7 +53825,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -53910,7 +53910,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -53978,7 +53978,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 60,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L60"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L60"
 								}
 							],
 							"signatures": [
@@ -54036,7 +54036,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -54104,7 +54104,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 172,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L172"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L172"
 								}
 							],
 							"signatures": [
@@ -54221,7 +54221,7 @@
 							"fileName": "src/lighting/AbstractLightModel.ts",
 							"line": 14,
 							"character": 30,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L14"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L14"
 						}
 					],
 					"typeParameters": [
@@ -54304,7 +54304,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 34,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L34"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L34"
 								}
 							],
 							"signatures": [
@@ -54448,7 +54448,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -54486,7 +54486,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -54520,7 +54520,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -54554,7 +54554,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -54588,7 +54588,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -54637,7 +54637,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 26,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L26"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L26"
 								}
 							],
 							"type": {
@@ -54670,7 +54670,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 19,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L19"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L19"
 								}
 							],
 							"type": {
@@ -54706,7 +54706,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 24,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L24"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L24"
 								}
 							],
 							"type": {
@@ -54739,7 +54739,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 21,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L21"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L21"
 								}
 							],
 							"type": {
@@ -54777,7 +54777,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 16,
 									"character": 20,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L16"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L16"
 								}
 							],
 							"type": {
@@ -54802,7 +54802,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -54845,7 +54845,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -54888,7 +54888,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -54931,7 +54931,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 73,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L73"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L73"
 								}
 							],
 							"signatures": [
@@ -54999,7 +54999,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -55097,7 +55097,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 48,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L48"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L48"
 								}
 							],
 							"signatures": [
@@ -55165,7 +55165,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -55233,7 +55233,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -55337,7 +55337,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -55384,7 +55384,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -55452,7 +55452,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -55522,7 +55522,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 96,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L96"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L96"
 								}
 							],
 							"signatures": [
@@ -55628,7 +55628,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -55674,7 +55674,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -55722,7 +55722,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 103,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L103"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L103"
 								}
 							],
 							"signatures": [
@@ -55811,7 +55811,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -55896,7 +55896,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -55964,7 +55964,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 60,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L60"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L60"
 								}
 							],
 							"signatures": [
@@ -56032,7 +56032,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -56100,7 +56100,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L119"
 								}
 							],
 							"signatures": [
@@ -56217,7 +56217,7 @@
 							"fileName": "src/lighting/AbstractLightModel.ts",
 							"line": 114,
 							"character": 22,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L114"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L114"
 						}
 					],
 					"typeParameters": [
@@ -56275,7 +56275,7 @@
 					"fileName": "src/lighting/AbstractLightModel.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L1"
 				}
 			]
 		},
@@ -56313,7 +56313,7 @@
 									"fileName": "src/lighting/DirectionalLight.ts",
 									"line": 28,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/DirectionalLight.ts#L28"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/DirectionalLight.ts#L28"
 								}
 							],
 							"signatures": [
@@ -56360,7 +56360,7 @@
 									"fileName": "src/lighting/DirectionalLight.ts",
 									"line": 25,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/DirectionalLight.ts#L25"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/DirectionalLight.ts#L25"
 								}
 							],
 							"type": {
@@ -56458,7 +56458,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 34,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L34"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L34"
 								}
 							],
 							"type": {
@@ -56492,7 +56492,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 38,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L38"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L38"
 								}
 							],
 							"type": {
@@ -56621,7 +56621,7 @@
 									"fileName": "src/lighting/DirectionalLight.ts",
 									"line": 23,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/DirectionalLight.ts#L23"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/DirectionalLight.ts#L23"
 								}
 							],
 							"type": {
@@ -56650,7 +56650,7 @@
 									"fileName": "src/lighting/DirectionalLight.ts",
 									"line": 17,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/DirectionalLight.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/DirectionalLight.ts#L17"
 								}
 							],
 							"type": {
@@ -56689,7 +56689,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 36,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L36"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L36"
 								}
 							],
 							"type": {
@@ -56888,7 +56888,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 45,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L45"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L45"
 								}
 							],
 							"type": {
@@ -56926,13 +56926,13 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 68,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L68"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L68"
 								},
 								{
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 77,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L77"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L77"
 								}
 							],
 							"getSignature": {
@@ -57364,7 +57364,7 @@
 									"fileName": "src/lighting/DirectionalLight.ts",
 									"line": 50,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/DirectionalLight.ts#L50"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/DirectionalLight.ts#L50"
 								}
 							],
 							"signatures": [
@@ -57488,7 +57488,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 146,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L146"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L146"
 								}
 							],
 							"signatures": [
@@ -57568,7 +57568,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 194,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L194"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L194"
 								}
 							],
 							"signatures": [
@@ -57682,7 +57682,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 120,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L120"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L120"
 								}
 							],
 							"signatures": [
@@ -57738,7 +57738,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 223,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L223"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L223"
 								}
 							],
 							"signatures": [
@@ -57808,7 +57808,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 183,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L183"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L183"
 								}
 							],
 							"signatures": [
@@ -57874,7 +57874,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 132,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L132"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L132"
 								}
 							],
 							"signatures": [
@@ -57954,7 +57954,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L105"
 								}
 							],
 							"signatures": [
@@ -58021,7 +58021,7 @@
 									"fileName": "src/lighting/DirectionalLight.ts",
 									"line": 43,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/DirectionalLight.ts#L43"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/DirectionalLight.ts#L43"
 								}
 							],
 							"signatures": [
@@ -58079,7 +58079,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 85,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L85"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L85"
 								}
 							],
 							"signatures": [
@@ -58135,7 +58135,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 93,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L93"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L93"
 								}
 							],
 							"signatures": [
@@ -58333,7 +58333,7 @@
 									"fileName": "src/lighting/DirectionalLight.ts",
 									"line": 34,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/DirectionalLight.ts#L34"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/DirectionalLight.ts#L34"
 								}
 							],
 							"signatures": [
@@ -58991,7 +58991,7 @@
 							"fileName": "src/lighting/DirectionalLight.ts",
 							"line": 15,
 							"character": 6,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/DirectionalLight.ts#L15"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/DirectionalLight.ts#L15"
 						}
 					],
 					"extendedTypes": [
@@ -59023,7 +59023,7 @@
 					"fileName": "src/lighting/DirectionalLight.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/DirectionalLight.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/DirectionalLight.ts#L1"
 				}
 			]
 		},
@@ -59061,7 +59061,7 @@
 									"fileName": "src/lighting/DirectionalLightModel.ts",
 									"line": 26,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/DirectionalLightModel.ts#L26"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/DirectionalLightModel.ts#L26"
 								}
 							],
 							"signatures": [
@@ -59152,7 +59152,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -59188,7 +59188,7 @@
 									"fileName": "src/lighting/DirectionalLightModel.ts",
 									"line": 20,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/DirectionalLightModel.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/DirectionalLightModel.ts#L20"
 								}
 							],
 							"type": {
@@ -59226,7 +59226,7 @@
 									"fileName": "src/lighting/DirectionalLightModel.ts",
 									"line": 18,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/DirectionalLightModel.ts#L18"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/DirectionalLightModel.ts#L18"
 								}
 							],
 							"type": {
@@ -59266,7 +59266,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -59300,7 +59300,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -59334,7 +59334,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -59368,7 +59368,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -59410,7 +59410,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 26,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L26"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L26"
 								}
 							],
 							"type": {
@@ -59443,7 +59443,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 19,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L19"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L19"
 								}
 							],
 							"type": {
@@ -59479,7 +59479,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 24,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L24"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L24"
 								}
 							],
 							"type": {
@@ -59512,7 +59512,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 21,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L21"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L21"
 								}
 							],
 							"type": {
@@ -59549,7 +59549,7 @@
 									"fileName": "src/lighting/DirectionalLightModel.ts",
 									"line": 15,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/DirectionalLightModel.ts#L15"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/DirectionalLightModel.ts#L15"
 								}
 							],
 							"type": {
@@ -59575,7 +59575,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -59618,7 +59618,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -59661,7 +59661,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -59704,7 +59704,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 73,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L73"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L73"
 								}
 							],
 							"signatures": [
@@ -59772,7 +59772,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -59870,7 +59870,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 48,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L48"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L48"
 								}
 							],
 							"signatures": [
@@ -59938,7 +59938,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -60006,7 +60006,7 @@
 									"fileName": "src/lighting/DirectionalLightModel.ts",
 									"line": 48,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/DirectionalLightModel.ts#L48"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/DirectionalLightModel.ts#L48"
 								}
 							],
 							"signatures": [
@@ -60063,7 +60063,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -60167,7 +60167,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -60214,7 +60214,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -60282,7 +60282,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -60350,7 +60350,7 @@
 									"fileName": "src/lighting/DirectionalLightModel.ts",
 									"line": 35,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/DirectionalLightModel.ts#L35"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/DirectionalLightModel.ts#L35"
 								}
 							],
 							"signatures": [
@@ -60456,7 +60456,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -60502,7 +60502,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -60548,7 +60548,7 @@
 									"fileName": "src/lighting/DirectionalLightModel.ts",
 									"line": 57,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/DirectionalLightModel.ts#L57"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/DirectionalLightModel.ts#L57"
 								}
 							],
 							"signatures": [
@@ -60637,7 +60637,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -60715,7 +60715,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -60783,7 +60783,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 60,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L60"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L60"
 								}
 							],
 							"signatures": [
@@ -60851,7 +60851,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -60919,7 +60919,7 @@
 									"fileName": "src/lighting/DirectionalLightModel.ts",
 									"line": 84,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/DirectionalLightModel.ts#L84"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/DirectionalLightModel.ts#L84"
 								}
 							],
 							"signatures": [
@@ -61039,7 +61039,7 @@
 							"fileName": "src/lighting/DirectionalLightModel.ts",
 							"line": 13,
 							"character": 21,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/DirectionalLightModel.ts#L13"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/DirectionalLightModel.ts#L13"
 						}
 					],
 					"extendedTypes": [
@@ -61071,7 +61071,7 @@
 					"fileName": "src/lighting/DirectionalLightModel.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/DirectionalLightModel.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/DirectionalLightModel.ts#L1"
 				}
 			]
 		},
@@ -61109,7 +61109,7 @@
 									"fileName": "src/lighting/Ibl.ts",
 									"line": 64,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Ibl.ts#L64"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Ibl.ts#L64"
 								}
 							],
 							"signatures": [
@@ -61306,7 +61306,7 @@
 									"fileName": "src/lighting/Ibl.ts",
 									"line": 20,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Ibl.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Ibl.ts#L20"
 								}
 							],
 							"type": {
@@ -61396,7 +61396,7 @@
 									"fileName": "src/lighting/Ibl.ts",
 									"line": 46,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Ibl.ts#L46"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Ibl.ts#L46"
 								}
 							],
 							"type": {
@@ -61426,7 +61426,7 @@
 									"fileName": "src/lighting/Ibl.ts",
 									"line": 58,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Ibl.ts#L58"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Ibl.ts#L58"
 								}
 							],
 							"type": {
@@ -61458,7 +61458,7 @@
 									"fileName": "src/lighting/Ibl.ts",
 									"line": 52,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Ibl.ts#L52"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Ibl.ts#L52"
 								}
 							],
 							"type": {
@@ -61488,7 +61488,7 @@
 									"fileName": "src/lighting/Ibl.ts",
 									"line": 40,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Ibl.ts#L40"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Ibl.ts#L40"
 								}
 							],
 							"type": {
@@ -61516,7 +61516,7 @@
 									"fileName": "src/lighting/Ibl.ts",
 									"line": 37,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Ibl.ts#L37"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Ibl.ts#L37"
 								}
 							],
 							"type": {
@@ -61547,7 +61547,7 @@
 									"fileName": "src/lighting/Ibl.ts",
 									"line": 64,
 									"character": 22,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Ibl.ts#L64"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Ibl.ts#L64"
 								}
 							],
 							"type": {
@@ -61576,7 +61576,7 @@
 									"fileName": "src/lighting/Ibl.ts",
 									"line": 25,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Ibl.ts#L25"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Ibl.ts#L25"
 								}
 							],
 							"type": {
@@ -61617,7 +61617,7 @@
 									"fileName": "src/lighting/Ibl.ts",
 									"line": 23,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Ibl.ts#L23"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Ibl.ts#L23"
 								}
 							],
 							"type": {
@@ -61654,7 +61654,7 @@
 									"fileName": "src/lighting/Ibl.ts",
 									"line": 43,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Ibl.ts#L43"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Ibl.ts#L43"
 								}
 							],
 							"type": {
@@ -61690,7 +61690,7 @@
 									"fileName": "src/lighting/Ibl.ts",
 									"line": 34,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Ibl.ts#L34"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Ibl.ts#L34"
 								}
 							],
 							"type": {
@@ -61805,7 +61805,7 @@
 									"fileName": "src/lighting/Ibl.ts",
 									"line": 64,
 									"character": 45,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Ibl.ts#L64"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Ibl.ts#L64"
 								}
 							],
 							"type": {
@@ -61840,7 +61840,7 @@
 									"fileName": "src/lighting/Ibl.ts",
 									"line": 27,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Ibl.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Ibl.ts#L27"
 								}
 							],
 							"type": {
@@ -61877,7 +61877,7 @@
 									"fileName": "src/lighting/Ibl.ts",
 									"line": 49,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Ibl.ts#L49"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Ibl.ts#L49"
 								}
 							],
 							"type": {
@@ -62885,7 +62885,7 @@
 							"fileName": "src/lighting/Ibl.ts",
 							"line": 18,
 							"character": 21,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Ibl.ts#L18"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Ibl.ts#L18"
 						}
 					],
 					"extendedTypes": [
@@ -62910,7 +62910,7 @@
 					"fileName": "src/lighting/Ibl.ts",
 					"line": 2,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Ibl.ts#L2"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Ibl.ts#L2"
 				}
 			]
 		},
@@ -62947,7 +62947,7 @@
 									"fileName": "src/lighting/IblModel.ts",
 									"line": 123,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L123"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L123"
 								}
 							],
 							"signatures": [
@@ -63038,7 +63038,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -63076,7 +63076,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -63110,7 +63110,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -63144,7 +63144,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -63178,7 +63178,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -63220,7 +63220,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 26,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L26"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L26"
 								}
 							],
 							"type": {
@@ -63256,7 +63256,7 @@
 									"fileName": "src/lighting/IblModel.ts",
 									"line": 71,
 									"character": 19,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L71"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L71"
 								}
 							],
 							"type": {
@@ -63294,7 +63294,7 @@
 									"fileName": "src/lighting/IblModel.ts",
 									"line": 69,
 									"character": 19,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L69"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L69"
 								}
 							],
 							"type": {
@@ -63332,7 +63332,7 @@
 									"fileName": "src/lighting/IblModel.ts",
 									"line": 78,
 									"character": 19,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L78"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L78"
 								}
 							],
 							"type": {
@@ -63387,7 +63387,7 @@
 									"fileName": "src/lighting/IblModel.ts",
 									"line": 74,
 									"character": 19,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L74"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L74"
 								}
 							],
 							"type": {
@@ -63438,7 +63438,7 @@
 									"fileName": "src/lighting/IblModel.ts",
 									"line": 80,
 									"character": 19,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L80"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L80"
 								}
 							],
 							"type": {
@@ -63478,7 +63478,7 @@
 									"fileName": "src/lighting/IblModel.ts",
 									"line": 85,
 									"character": 19,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L85"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L85"
 								}
 							],
 							"type": {
@@ -63506,7 +63506,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 19,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L19"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L19"
 								}
 							],
 							"type": {
@@ -63545,7 +63545,7 @@
 									"fileName": "src/lighting/IblModel.ts",
 									"line": 82,
 									"character": 19,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L82"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L82"
 								}
 							],
 							"type": {
@@ -63585,7 +63585,7 @@
 									"fileName": "src/lighting/IblModel.ts",
 									"line": 87,
 									"character": 19,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L87"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L87"
 								}
 							],
 							"type": {
@@ -63613,7 +63613,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 24,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L24"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L24"
 								}
 							],
 							"type": {
@@ -63649,7 +63649,7 @@
 									"fileName": "src/lighting/IblModel.ts",
 									"line": 76,
 									"character": 19,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L76"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L76"
 								}
 							],
 							"type": {
@@ -63697,7 +63697,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 21,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L21"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L21"
 								}
 							],
 							"type": {
@@ -63734,7 +63734,7 @@
 									"fileName": "src/lighting/IblModel.ts",
 									"line": 66,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L66"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L66"
 								}
 							],
 							"type": {
@@ -63760,7 +63760,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -63803,7 +63803,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -63846,7 +63846,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -63889,7 +63889,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 73,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L73"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L73"
 								}
 							],
 							"signatures": [
@@ -63957,7 +63957,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -64055,7 +64055,7 @@
 									"fileName": "src/lighting/IblModel.ts",
 									"line": 111,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L111"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L111"
 								}
 							],
 							"signatures": [
@@ -64123,7 +64123,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -64191,7 +64191,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -64295,7 +64295,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -64342,7 +64342,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -64410,7 +64410,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -64478,7 +64478,7 @@
 									"fileName": "src/lighting/IblModel.ts",
 									"line": 90,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L90"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L90"
 								}
 							],
 							"signatures": [
@@ -64584,7 +64584,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -64630,7 +64630,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -64676,7 +64676,7 @@
 									"fileName": "src/lighting/IblModel.ts",
 									"line": 94,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L94"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L94"
 								}
 							],
 							"signatures": [
@@ -64765,7 +64765,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -64843,7 +64843,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -64911,7 +64911,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 60,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L60"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L60"
 								}
 							],
 							"signatures": [
@@ -64979,7 +64979,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -65047,7 +65047,7 @@
 									"fileName": "src/lighting/IblModel.ts",
 									"line": 141,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L141"
 								}
 							],
 							"signatures": [
@@ -65173,7 +65173,7 @@
 							"fileName": "src/lighting/IblModel.ts",
 							"line": 64,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L64"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L64"
 						}
 					],
 					"extendedTypes": [
@@ -65213,7 +65213,7 @@
 							"fileName": "src/lighting/IblModel.ts",
 							"line": 57,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L57"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L57"
 						}
 					],
 					"type": {
@@ -65254,7 +65254,7 @@
 							"fileName": "src/lighting/IblModel.ts",
 							"line": 47,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L47"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L47"
 						}
 					],
 					"type": {
@@ -65295,7 +65295,7 @@
 							"fileName": "src/lighting/IblModel.ts",
 							"line": 52,
 							"character": 12,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L52"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L52"
 						}
 					],
 					"type": {
@@ -65335,7 +65335,7 @@
 							"fileName": "src/lighting/IblModel.ts",
 							"line": 34,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L34"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L34"
 						}
 					],
 					"type": {
@@ -65382,7 +65382,7 @@
 							"fileName": "src/lighting/IblModel.ts",
 							"line": 18,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L18"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L18"
 						}
 					],
 					"type": {
@@ -65425,7 +65425,7 @@
 							"fileName": "src/lighting/IblModel.ts",
 							"line": 26,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L26"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L26"
 						}
 					],
 					"type": {
@@ -65477,7 +65477,7 @@
 					"fileName": "src/lighting/IblModel.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/IblModel.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/IblModel.ts#L1"
 				}
 			]
 		},
@@ -65517,7 +65517,7 @@
 									"fileName": "src/lighting/Light.ts",
 									"line": 19,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Light.ts#L19"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Light.ts#L19"
 								}
 							],
 							"signatures": [
@@ -65656,7 +65656,7 @@
 									"fileName": "src/lighting/Light.ts",
 									"line": 17,
 									"character": 20,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Light.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Light.ts#L17"
 								}
 							],
 							"type": {
@@ -66757,7 +66757,7 @@
 							"fileName": "src/lighting/Light.ts",
 							"line": 15,
 							"character": 30,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Light.ts#L15"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Light.ts#L15"
 						}
 					],
 					"extendedTypes": [
@@ -66917,7 +66917,7 @@
 									"fileName": "src/lighting/Light.ts",
 									"line": 17,
 									"character": 20,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Light.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Light.ts#L17"
 								}
 							],
 							"type": {
@@ -67006,7 +67006,7 @@
 									"fileName": "src/lighting/Light.ts",
 									"line": 38,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Light.ts#L38"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Light.ts#L38"
 								}
 							],
 							"type": {
@@ -67117,7 +67117,7 @@
 									"fileName": "src/lighting/Light.ts",
 									"line": 40,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Light.ts#L40"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Light.ts#L40"
 								}
 							],
 							"type": {
@@ -67531,7 +67531,7 @@
 									"fileName": "src/lighting/Light.ts",
 									"line": 64,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Light.ts#L64"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Light.ts#L64"
 								}
 							],
 							"signatures": [
@@ -67567,7 +67567,7 @@
 									"fileName": "src/lighting/Light.ts",
 									"line": 79,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Light.ts#L79"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Light.ts#L79"
 								}
 							],
 							"signatures": [
@@ -67613,7 +67613,7 @@
 									"fileName": "src/lighting/Light.ts",
 									"line": 85,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Light.ts#L85"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Light.ts#L85"
 								}
 							],
 							"signatures": [
@@ -67673,7 +67673,7 @@
 									"fileName": "src/lighting/Light.ts",
 									"line": 59,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Light.ts#L59"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Light.ts#L59"
 								}
 							],
 							"signatures": [
@@ -67720,7 +67720,7 @@
 									"fileName": "src/lighting/Light.ts",
 									"line": 74,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Light.ts#L74"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Light.ts#L74"
 								}
 							],
 							"signatures": [
@@ -67758,7 +67758,7 @@
 									"fileName": "src/lighting/Light.ts",
 									"line": 69,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Light.ts#L69"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Light.ts#L69"
 								}
 							],
 							"signatures": [
@@ -67794,7 +67794,7 @@
 									"fileName": "src/lighting/Light.ts",
 									"line": 53,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Light.ts#L53"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Light.ts#L53"
 								}
 							],
 							"signatures": [
@@ -67952,7 +67952,7 @@
 									"fileName": "src/lighting/Light.ts",
 									"line": 47,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Light.ts#L47"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Light.ts#L47"
 								}
 							],
 							"signatures": [
@@ -68495,7 +68495,7 @@
 							"fileName": "src/lighting/Light.ts",
 							"line": 36,
 							"character": 17,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Light.ts#L36"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Light.ts#L36"
 						}
 					],
 					"extendedTypes": [
@@ -68529,7 +68529,7 @@
 							"fileName": "src/lighting/Light.ts",
 							"line": 29,
 							"character": 16,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Light.ts#L29"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Light.ts#L29"
 						}
 					],
 					"signatures": [
@@ -68608,7 +68608,7 @@
 					"fileName": "src/lighting/Light.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Light.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Light.ts#L1"
 				}
 			]
 		},
@@ -68646,7 +68646,7 @@
 									"fileName": "src/lighting/LightSetup.ts",
 									"line": 34,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/LightSetup.ts#L34"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/LightSetup.ts#L34"
 								}
 							],
 							"signatures": [
@@ -68683,7 +68683,7 @@
 									"fileName": "src/lighting/LightSetup.ts",
 									"line": 19,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/LightSetup.ts#L19"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/LightSetup.ts#L19"
 								}
 							],
 							"type": {
@@ -68714,7 +68714,7 @@
 									"fileName": "src/lighting/LightSetup.ts",
 									"line": 28,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/LightSetup.ts#L28"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/LightSetup.ts#L28"
 								}
 							],
 							"type": {
@@ -68745,7 +68745,7 @@
 									"fileName": "src/lighting/LightSetup.ts",
 									"line": 30,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/LightSetup.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/LightSetup.ts#L30"
 								}
 							],
 							"type": {
@@ -68785,7 +68785,7 @@
 									"fileName": "src/lighting/LightSetup.ts",
 									"line": 23,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/LightSetup.ts#L23"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/LightSetup.ts#L23"
 								}
 							],
 							"type": {
@@ -68813,7 +68813,7 @@
 									"fileName": "src/lighting/LightSetup.ts",
 									"line": 21,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/LightSetup.ts#L21"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/LightSetup.ts#L21"
 								}
 							],
 							"type": {
@@ -68841,7 +68841,7 @@
 									"fileName": "src/lighting/LightSetup.ts",
 									"line": 25,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/LightSetup.ts#L25"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/LightSetup.ts#L25"
 								}
 							],
 							"type": {
@@ -68861,7 +68861,7 @@
 									"fileName": "src/lighting/LightSetup.ts",
 									"line": 120,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/LightSetup.ts#L120"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/LightSetup.ts#L120"
 								}
 							],
 							"signatures": [
@@ -68938,7 +68938,7 @@
 									"fileName": "src/lighting/LightSetup.ts",
 									"line": 58,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/LightSetup.ts#L58"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/LightSetup.ts#L58"
 								}
 							],
 							"signatures": [
@@ -68996,7 +68996,7 @@
 									"fileName": "src/lighting/LightSetup.ts",
 									"line": 103,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/LightSetup.ts#L103"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/LightSetup.ts#L103"
 								}
 							],
 							"signatures": [
@@ -69057,7 +69057,7 @@
 									"fileName": "src/lighting/LightSetup.ts",
 									"line": 91,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/LightSetup.ts#L91"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/LightSetup.ts#L91"
 								}
 							],
 							"signatures": [
@@ -69116,7 +69116,7 @@
 									"fileName": "src/lighting/LightSetup.ts",
 									"line": 76,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/LightSetup.ts#L76"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/LightSetup.ts#L76"
 								}
 							],
 							"signatures": [
@@ -69198,7 +69198,7 @@
 							"fileName": "src/lighting/LightSetup.ts",
 							"line": 17,
 							"character": 6,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/LightSetup.ts#L17"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/LightSetup.ts#L17"
 						}
 					]
 				}
@@ -69216,7 +69216,7 @@
 					"fileName": "src/lighting/LightSetup.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/LightSetup.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/LightSetup.ts#L1"
 				}
 			]
 		},
@@ -69254,7 +69254,7 @@
 									"fileName": "src/lighting/LightType.ts",
 									"line": 4,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/LightType.ts#L4"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/LightType.ts#L4"
 								}
 							],
 							"type": {
@@ -69273,7 +69273,7 @@
 									"fileName": "src/lighting/LightType.ts",
 									"line": 7,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/LightType.ts#L7"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/LightType.ts#L7"
 								}
 							],
 							"type": {
@@ -69292,7 +69292,7 @@
 									"fileName": "src/lighting/LightType.ts",
 									"line": 6,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/LightType.ts#L6"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/LightType.ts#L6"
 								}
 							],
 							"type": {
@@ -69311,7 +69311,7 @@
 									"fileName": "src/lighting/LightType.ts",
 									"line": 5,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/LightType.ts#L5"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/LightType.ts#L5"
 								}
 							],
 							"type": {
@@ -69330,7 +69330,7 @@
 									"fileName": "src/lighting/LightType.ts",
 									"line": 3,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/LightType.ts#L3"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/LightType.ts#L3"
 								}
 							],
 							"type": {
@@ -69356,7 +69356,7 @@
 							"fileName": "src/lighting/LightType.ts",
 							"line": 2,
 							"character": 5,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/LightType.ts#L2"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/LightType.ts#L2"
 						}
 					]
 				}
@@ -69374,7 +69374,7 @@
 					"fileName": "src/lighting/LightType.ts",
 					"line": 2,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/LightType.ts#L2"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/LightType.ts#L2"
 				}
 			]
 		},
@@ -69412,7 +69412,7 @@
 									"fileName": "src/lighting/PointLight.ts",
 									"line": 17,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PointLight.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PointLight.ts#L17"
 								}
 							],
 							"signatures": [
@@ -69459,7 +69459,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 40,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L40"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L40"
 								}
 							],
 							"type": {
@@ -69551,7 +69551,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 34,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L34"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L34"
 								}
 							],
 							"type": {
@@ -69585,7 +69585,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 38,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L38"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L38"
 								}
 							],
 							"type": {
@@ -69695,7 +69695,7 @@
 									"fileName": "src/lighting/PointLight.ts",
 									"line": 15,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PointLight.ts#L15"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PointLight.ts#L15"
 								}
 							],
 							"type": {
@@ -69724,7 +69724,7 @@
 									"fileName": "src/lighting/PointLight.ts",
 									"line": 12,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PointLight.ts#L12"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PointLight.ts#L12"
 								}
 							],
 							"type": {
@@ -69758,7 +69758,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 36,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L36"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L36"
 								}
 							],
 							"type": {
@@ -69932,7 +69932,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 45,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L45"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L45"
 								}
 							],
 							"type": {
@@ -69957,7 +69957,7 @@
 									"fileName": "src/lighting/PointLight.ts",
 									"line": 25,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PointLight.ts#L25"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PointLight.ts#L25"
 								}
 							],
 							"setSignature": {
@@ -70021,13 +70021,13 @@
 									"fileName": "src/lighting/PointLight.ts",
 									"line": 32,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PointLight.ts#L32"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PointLight.ts#L32"
 								},
 								{
 									"fileName": "src/lighting/PointLight.ts",
 									"line": 37,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PointLight.ts#L37"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PointLight.ts#L37"
 								}
 							],
 							"getSignature": {
@@ -70382,7 +70382,7 @@
 									"fileName": "src/lighting/PointLight.ts",
 									"line": 55,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PointLight.ts#L55"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PointLight.ts#L55"
 								}
 							],
 							"signatures": [
@@ -70496,7 +70496,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 146,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L146"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L146"
 								}
 							],
 							"signatures": [
@@ -70576,7 +70576,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 194,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L194"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L194"
 								}
 							],
 							"signatures": [
@@ -70680,7 +70680,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 120,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L120"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L120"
 								}
 							],
 							"signatures": [
@@ -70726,7 +70726,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 223,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L223"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L223"
 								}
 							],
 							"signatures": [
@@ -70796,7 +70796,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 183,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L183"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L183"
 								}
 							],
 							"signatures": [
@@ -70852,7 +70852,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 132,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L132"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L132"
 								}
 							],
 							"signatures": [
@@ -70922,7 +70922,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L105"
 								}
 							],
 							"signatures": [
@@ -70979,7 +70979,7 @@
 									"fileName": "src/lighting/PointLight.ts",
 									"line": 63,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PointLight.ts#L63"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PointLight.ts#L63"
 								}
 							],
 							"signatures": [
@@ -71027,7 +71027,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 85,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L85"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L85"
 								}
 							],
 							"signatures": [
@@ -71073,7 +71073,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 93,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L93"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L93"
 								}
 							],
 							"signatures": [
@@ -71241,7 +71241,7 @@
 									"fileName": "src/lighting/PointLight.ts",
 									"line": 47,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PointLight.ts#L47"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PointLight.ts#L47"
 								}
 							],
 							"signatures": [
@@ -71804,7 +71804,7 @@
 							"fileName": "src/lighting/PointLight.ts",
 							"line": 10,
 							"character": 6,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PointLight.ts#L10"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PointLight.ts#L10"
 						}
 					],
 					"extendedTypes": [
@@ -71829,7 +71829,7 @@
 					"fileName": "src/lighting/PointLight.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PointLight.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PointLight.ts#L1"
 				}
 			]
 		},
@@ -71867,7 +71867,7 @@
 									"fileName": "src/lighting/PointLightModel.ts",
 									"line": 25,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PointLightModel.ts#L25"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PointLightModel.ts#L25"
 								}
 							],
 							"signatures": [
@@ -71958,7 +71958,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -71994,7 +71994,7 @@
 									"fileName": "src/lighting/PointLightModel.ts",
 									"line": 17,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PointLightModel.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PointLightModel.ts#L17"
 								}
 							],
 							"type": {
@@ -72034,7 +72034,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -72068,7 +72068,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -72102,7 +72102,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -72134,7 +72134,7 @@
 									"fileName": "src/lighting/PointLightModel.ts",
 									"line": 19,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PointLightModel.ts#L19"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PointLightModel.ts#L19"
 								}
 							],
 							"type": {
@@ -72174,7 +72174,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -72216,7 +72216,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 26,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L26"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L26"
 								}
 							],
 							"type": {
@@ -72249,7 +72249,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 19,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L19"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L19"
 								}
 							],
 							"type": {
@@ -72285,7 +72285,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 24,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L24"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L24"
 								}
 							],
 							"type": {
@@ -72318,7 +72318,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 21,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L21"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L21"
 								}
 							],
 							"type": {
@@ -72355,7 +72355,7 @@
 									"fileName": "src/lighting/PointLightModel.ts",
 									"line": 14,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PointLightModel.ts#L14"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PointLightModel.ts#L14"
 								}
 							],
 							"type": {
@@ -72381,7 +72381,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -72424,7 +72424,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -72467,7 +72467,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -72510,7 +72510,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 73,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L73"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L73"
 								}
 							],
 							"signatures": [
@@ -72578,7 +72578,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -72676,7 +72676,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 48,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L48"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L48"
 								}
 							],
 							"signatures": [
@@ -72744,7 +72744,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -72812,7 +72812,7 @@
 									"fileName": "src/lighting/PointLightModel.ts",
 									"line": 47,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PointLightModel.ts#L47"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PointLightModel.ts#L47"
 								}
 							],
 							"signatures": [
@@ -72869,7 +72869,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -72973,7 +72973,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -73020,7 +73020,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -73088,7 +73088,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -73156,7 +73156,7 @@
 									"fileName": "src/lighting/PointLightModel.ts",
 									"line": 34,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PointLightModel.ts#L34"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PointLightModel.ts#L34"
 								}
 							],
 							"signatures": [
@@ -73262,7 +73262,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -73308,7 +73308,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -73354,7 +73354,7 @@
 									"fileName": "src/lighting/PointLightModel.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PointLightModel.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PointLightModel.ts#L56"
 								}
 							],
 							"signatures": [
@@ -73443,7 +73443,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -73521,7 +73521,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -73589,7 +73589,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 60,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L60"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L60"
 								}
 							],
 							"signatures": [
@@ -73657,7 +73657,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -73725,7 +73725,7 @@
 									"fileName": "src/lighting/PointLightModel.ts",
 									"line": 84,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PointLightModel.ts#L84"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PointLightModel.ts#L84"
 								}
 							],
 							"signatures": [
@@ -73845,7 +73845,7 @@
 							"fileName": "src/lighting/PointLightModel.ts",
 							"line": 12,
 							"character": 21,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PointLightModel.ts#L12"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PointLightModel.ts#L12"
 						}
 					],
 					"extendedTypes": [
@@ -73877,7 +73877,7 @@
 					"fileName": "src/lighting/PointLightModel.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PointLightModel.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PointLightModel.ts#L1"
 				}
 			]
 		},
@@ -73917,7 +73917,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 48,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L48"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L48"
 								}
 							],
 							"signatures": [
@@ -73964,7 +73964,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 40,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L40"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L40"
 								}
 							],
 							"type": {
@@ -74012,7 +74012,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 62,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L62"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L62"
 								}
 							],
 							"type": {
@@ -74081,7 +74081,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 34,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L34"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L34"
 								}
 							],
 							"type": {
@@ -74110,7 +74110,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 38,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L38"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L38"
 								}
 							],
 							"type": {
@@ -74216,7 +74216,7 @@
 									"fileName": "src/lighting/Light.ts",
 									"line": 17,
 									"character": 20,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/Light.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/Light.ts#L17"
 								}
 							],
 							"type": {
@@ -74249,7 +74249,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 36,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L36"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L36"
 								}
 							],
 							"type": {
@@ -74418,7 +74418,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 45,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L45"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L45"
 								}
 							],
 							"type": {
@@ -74438,13 +74438,13 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 68,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L68"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L68"
 								},
 								{
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 77,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L77"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L77"
 								}
 							],
 							"getSignature": {
@@ -74802,7 +74802,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 215,
 									"character": 21,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L215"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L215"
 								}
 							],
 							"signatures": [
@@ -74906,7 +74906,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 146,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L146"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L146"
 								}
 							],
 							"signatures": [
@@ -74977,7 +74977,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 194,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L194"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L194"
 								}
 							],
 							"signatures": [
@@ -75071,7 +75071,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 120,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L120"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L120"
 								}
 							],
 							"signatures": [
@@ -75107,7 +75107,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 223,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L223"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L223"
 								}
 							],
 							"signatures": [
@@ -75167,7 +75167,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 183,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L183"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L183"
 								}
 							],
 							"signatures": [
@@ -75213,7 +75213,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 132,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L132"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L132"
 								}
 							],
 							"signatures": [
@@ -75273,7 +75273,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L105"
 								}
 							],
 							"signatures": [
@@ -75322,7 +75322,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 210,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L210"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L210"
 								}
 							],
 							"signatures": [
@@ -75360,7 +75360,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 85,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L85"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L85"
 								}
 							],
 							"signatures": [
@@ -75396,7 +75396,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 93,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L93"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L93"
 								}
 							],
 							"signatures": [
@@ -75556,7 +75556,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 206,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L206"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L206"
 								}
 							],
 							"signatures": [
@@ -76114,7 +76114,7 @@
 							"fileName": "src/lighting/PunctualLight.ts",
 							"line": 29,
 							"character": 30,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L29"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L29"
 						}
 					],
 					"extendedTypes": [
@@ -76156,7 +76156,7 @@
 					"fileName": "src/lighting/PunctualLight.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L1"
 				}
 			]
 		},
@@ -76194,7 +76194,7 @@
 									"fileName": "src/lighting/SpotLight.ts",
 									"line": 33,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLight.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLight.ts#L33"
 								}
 							],
 							"signatures": [
@@ -76241,7 +76241,7 @@
 									"fileName": "src/lighting/SpotLight.ts",
 									"line": 28,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLight.ts#L28"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLight.ts#L28"
 								}
 							],
 							"type": {
@@ -76270,7 +76270,7 @@
 									"fileName": "src/lighting/SpotLight.ts",
 									"line": 30,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLight.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLight.ts#L30"
 								}
 							],
 							"type": {
@@ -76368,7 +76368,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 34,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L34"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L34"
 								}
 							],
 							"type": {
@@ -76402,7 +76402,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 38,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L38"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L38"
 								}
 							],
 							"type": {
@@ -76448,7 +76448,7 @@
 									"fileName": "src/lighting/SpotLight.ts",
 									"line": 20,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLight.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLight.ts#L20"
 								}
 							],
 							"type": {
@@ -76511,7 +76511,7 @@
 									"fileName": "src/lighting/SpotLight.ts",
 									"line": 22,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLight.ts#L22"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLight.ts#L22"
 								}
 							],
 							"type": {
@@ -76582,7 +76582,7 @@
 									"fileName": "src/lighting/SpotLight.ts",
 									"line": 24,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLight.ts#L24"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLight.ts#L24"
 								}
 							],
 							"type": {
@@ -76612,7 +76612,7 @@
 									"fileName": "src/lighting/SpotLight.ts",
 									"line": 17,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLight.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLight.ts#L17"
 								}
 							],
 							"type": {
@@ -76651,7 +76651,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 36,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L36"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L36"
 								}
 							],
 							"type": {
@@ -76850,7 +76850,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 45,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L45"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L45"
 								}
 							],
 							"type": {
@@ -76880,13 +76880,13 @@
 									"fileName": "src/lighting/SpotLight.ts",
 									"line": 97,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLight.ts#L97"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLight.ts#L97"
 								},
 								{
 									"fileName": "src/lighting/SpotLight.ts",
 									"line": 103,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLight.ts#L103"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLight.ts#L103"
 								}
 							],
 							"getSignature": {
@@ -76968,13 +76968,13 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 68,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L68"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L68"
 								},
 								{
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 77,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L77"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L77"
 								}
 							],
 							"getSignature": {
@@ -77076,13 +77076,13 @@
 									"fileName": "src/lighting/SpotLight.ts",
 									"line": 83,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLight.ts#L83"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLight.ts#L83"
 								},
 								{
 									"fileName": "src/lighting/SpotLight.ts",
 									"line": 89,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLight.ts#L89"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLight.ts#L89"
 								}
 							],
 							"getSignature": {
@@ -77156,13 +77156,13 @@
 									"fileName": "src/lighting/SpotLight.ts",
 									"line": 108,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLight.ts#L108"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLight.ts#L108"
 								},
 								{
 									"fileName": "src/lighting/SpotLight.ts",
 									"line": 115,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLight.ts#L115"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLight.ts#L115"
 								}
 							],
 							"getSignature": {
@@ -77236,13 +77236,13 @@
 									"fileName": "src/lighting/SpotLight.ts",
 									"line": 127,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLight.ts#L127"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLight.ts#L127"
 								},
 								{
 									"fileName": "src/lighting/SpotLight.ts",
 									"line": 133,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLight.ts#L133"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLight.ts#L133"
 								}
 							],
 							"getSignature": {
@@ -77646,7 +77646,7 @@
 									"fileName": "src/lighting/SpotLight.ts",
 									"line": 70,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLight.ts#L70"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLight.ts#L70"
 								}
 							],
 							"signatures": [
@@ -77770,7 +77770,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 146,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L146"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L146"
 								}
 							],
 							"signatures": [
@@ -77850,7 +77850,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 194,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L194"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L194"
 								}
 							],
 							"signatures": [
@@ -77896,7 +77896,7 @@
 									"fileName": "src/lighting/SpotLight.ts",
 									"line": 142,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLight.ts#L142"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLight.ts#L142"
 								}
 							],
 							"signatures": [
@@ -78000,7 +78000,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 120,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L120"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L120"
 								}
 							],
 							"signatures": [
@@ -78056,7 +78056,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 223,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L223"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L223"
 								}
 							],
 							"signatures": [
@@ -78126,7 +78126,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 183,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L183"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L183"
 								}
 							],
 							"signatures": [
@@ -78192,7 +78192,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 132,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L132"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L132"
 								}
 							],
 							"signatures": [
@@ -78272,7 +78272,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L105"
 								}
 							],
 							"signatures": [
@@ -78339,7 +78339,7 @@
 									"fileName": "src/lighting/SpotLight.ts",
 									"line": 59,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLight.ts#L59"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLight.ts#L59"
 								}
 							],
 							"signatures": [
@@ -78397,7 +78397,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 85,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L85"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L85"
 								}
 							],
 							"signatures": [
@@ -78453,7 +78453,7 @@
 									"fileName": "src/lighting/PunctualLight.ts",
 									"line": 93,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/PunctualLight.ts#L93"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/PunctualLight.ts#L93"
 								}
 							],
 							"signatures": [
@@ -78651,7 +78651,7 @@
 									"fileName": "src/lighting/SpotLight.ts",
 									"line": 43,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLight.ts#L43"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLight.ts#L43"
 								}
 							],
 							"signatures": [
@@ -79317,7 +79317,7 @@
 							"fileName": "src/lighting/SpotLight.ts",
 							"line": 15,
 							"character": 6,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLight.ts#L15"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLight.ts#L15"
 						}
 					],
 					"extendedTypes": [
@@ -79349,7 +79349,7 @@
 					"fileName": "src/lighting/SpotLight.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLight.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLight.ts#L1"
 				}
 			]
 		},
@@ -79387,7 +79387,7 @@
 									"fileName": "src/lighting/SpotLightModel.ts",
 									"line": 31,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLightModel.ts#L31"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLightModel.ts#L31"
 								}
 							],
 							"signatures": [
@@ -79476,7 +79476,7 @@
 									"fileName": "src/lighting/SpotLightModel.ts",
 									"line": 25,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLightModel.ts#L25"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLightModel.ts#L25"
 								}
 							],
 							"type": {
@@ -79516,7 +79516,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -79552,7 +79552,7 @@
 									"fileName": "src/lighting/SpotLightModel.ts",
 									"line": 23,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLightModel.ts#L23"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLightModel.ts#L23"
 								}
 							],
 							"type": {
@@ -79590,7 +79590,7 @@
 									"fileName": "src/lighting/SpotLightModel.ts",
 									"line": 21,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLightModel.ts#L21"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLightModel.ts#L21"
 								}
 							],
 							"type": {
@@ -79630,7 +79630,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -79664,7 +79664,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -79698,7 +79698,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -79730,7 +79730,7 @@
 									"fileName": "src/lighting/SpotLightModel.ts",
 									"line": 19,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLightModel.ts#L19"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLightModel.ts#L19"
 								}
 							],
 							"type": {
@@ -79770,7 +79770,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -79812,7 +79812,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 26,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L26"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L26"
 								}
 							],
 							"type": {
@@ -79845,7 +79845,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 19,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L19"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L19"
 								}
 							],
 							"type": {
@@ -79881,7 +79881,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 24,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L24"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L24"
 								}
 							],
 							"type": {
@@ -79914,7 +79914,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 21,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L21"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L21"
 								}
 							],
 							"type": {
@@ -79951,7 +79951,7 @@
 									"fileName": "src/lighting/SpotLightModel.ts",
 									"line": 16,
 									"character": 11,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLightModel.ts#L16"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLightModel.ts#L16"
 								}
 							],
 							"type": {
@@ -79977,7 +79977,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -80020,7 +80020,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -80063,7 +80063,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -80106,7 +80106,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 73,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L73"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L73"
 								}
 							],
 							"signatures": [
@@ -80174,7 +80174,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -80272,7 +80272,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 48,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L48"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L48"
 								}
 							],
 							"signatures": [
@@ -80340,7 +80340,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -80408,7 +80408,7 @@
 									"fileName": "src/lighting/SpotLightModel.ts",
 									"line": 58,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLightModel.ts#L58"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLightModel.ts#L58"
 								}
 							],
 							"signatures": [
@@ -80465,7 +80465,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -80569,7 +80569,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -80616,7 +80616,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -80684,7 +80684,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -80752,7 +80752,7 @@
 									"fileName": "src/lighting/SpotLightModel.ts",
 									"line": 44,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLightModel.ts#L44"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLightModel.ts#L44"
 								}
 							],
 							"signatures": [
@@ -80858,7 +80858,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -80904,7 +80904,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -80950,7 +80950,7 @@
 									"fileName": "src/lighting/SpotLightModel.ts",
 									"line": 69,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLightModel.ts#L69"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLightModel.ts#L69"
 								}
 							],
 							"signatures": [
@@ -81039,7 +81039,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -81117,7 +81117,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -81185,7 +81185,7 @@
 									"fileName": "src/lighting/AbstractLightModel.ts",
 									"line": 60,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/AbstractLightModel.ts#L60"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/AbstractLightModel.ts#L60"
 								}
 							],
 							"signatures": [
@@ -81253,7 +81253,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -81321,7 +81321,7 @@
 									"fileName": "src/lighting/SpotLightModel.ts",
 									"line": 100,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLightModel.ts#L100"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLightModel.ts#L100"
 								}
 							],
 							"signatures": [
@@ -81443,7 +81443,7 @@
 							"fileName": "src/lighting/SpotLightModel.ts",
 							"line": 13,
 							"character": 21,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLightModel.ts#L13"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLightModel.ts#L13"
 						}
 					],
 					"extendedTypes": [
@@ -81475,7 +81475,7 @@
 					"fileName": "src/lighting/SpotLightModel.ts",
 					"line": 1,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/SpotLightModel.ts#L1"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/SpotLightModel.ts#L1"
 				}
 			]
 		},
@@ -81512,7 +81512,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 233,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L233"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L233"
 								}
 							],
 							"signatures": [
@@ -81583,7 +81583,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -81621,7 +81621,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -81655,7 +81655,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -81689,7 +81689,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -81723,7 +81723,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -81765,7 +81765,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 228,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L228"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L228"
 								}
 							],
 							"type": {
@@ -81785,7 +81785,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -81828,7 +81828,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -81871,7 +81871,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -81914,7 +81914,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 242,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L242"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L242"
 								}
 							],
 							"signatures": [
@@ -81982,7 +81982,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -82080,7 +82080,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -82148,7 +82148,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -82252,7 +82252,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -82299,7 +82299,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -82367,7 +82367,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -82435,7 +82435,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -82481,7 +82481,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -82527,7 +82527,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -82605,7 +82605,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -82673,7 +82673,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -82741,7 +82741,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 172,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L172"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L172"
 								}
 							],
 							"signatures": [
@@ -82850,7 +82850,7 @@
 							"fileName": "src/lighting/StandardModel.ts",
 							"line": 226,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L226"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L226"
 						}
 					],
 					"extendedTypes": [
@@ -82887,7 +82887,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L204"
 								}
 							],
 							"signatures": [
@@ -82958,7 +82958,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -82996,7 +82996,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -83030,7 +83030,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -83064,7 +83064,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -83098,7 +83098,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -83140,7 +83140,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 199,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L199"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L199"
 								}
 							],
 							"type": {
@@ -83160,7 +83160,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -83203,7 +83203,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -83246,7 +83246,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -83289,7 +83289,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 213,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L213"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L213"
 								}
 							],
 							"signatures": [
@@ -83357,7 +83357,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -83455,7 +83455,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -83523,7 +83523,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -83627,7 +83627,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -83674,7 +83674,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -83742,7 +83742,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -83810,7 +83810,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -83856,7 +83856,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -83902,7 +83902,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -83980,7 +83980,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -84048,7 +84048,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -84116,7 +84116,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 172,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L172"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L172"
 								}
 							],
 							"signatures": [
@@ -84225,7 +84225,7 @@
 							"fileName": "src/lighting/StandardModel.ts",
 							"line": 197,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L197"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L197"
 						}
 					],
 					"extendedTypes": [
@@ -84262,7 +84262,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 288,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L288"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L288"
 								}
 							],
 							"signatures": [
@@ -84333,7 +84333,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 33,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L33"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L33"
 								}
 							],
 							"type": {
@@ -84371,7 +84371,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 17,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L17"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L17"
 								}
 							],
 							"type": {
@@ -84405,7 +84405,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 20,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L20"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L20"
 								}
 							],
 							"type": {
@@ -84439,7 +84439,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 27,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L27"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L27"
 								}
 							],
 							"type": {
@@ -84471,7 +84471,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 271,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L271"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L271"
 								}
 							],
 							"type": {
@@ -84502,7 +84502,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 30,
 									"character": 12,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L30"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L30"
 								}
 							],
 							"type": {
@@ -84544,7 +84544,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 275,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L275"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L275"
 								}
 							],
 							"type": {
@@ -84573,7 +84573,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 273,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L273"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L273"
 								}
 							],
 							"type": {
@@ -84602,7 +84602,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 278,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L278"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L278"
 								}
 							],
 							"type": {
@@ -84640,7 +84640,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 282,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L282"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L282"
 								}
 							],
 							"type": {
@@ -84678,7 +84678,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 280,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L280"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L280"
 								}
 							],
 							"type": {
@@ -84716,7 +84716,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 268,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L268"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L268"
 								}
 							],
 							"type": {
@@ -84743,7 +84743,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 263,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L263"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L263"
 								}
 							],
 							"type": {
@@ -84771,7 +84771,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 266,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L266"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L266"
 								}
 							],
 							"type": {
@@ -84790,7 +84790,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 130,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L130"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L130"
 								}
 							],
 							"getSignature": {
@@ -84833,7 +84833,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 141,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L141"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L141"
 								}
 							],
 							"getSignature": {
@@ -84876,7 +84876,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 152,
 									"character": 6,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L152"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L152"
 								}
 							],
 							"getSignature": {
@@ -84919,7 +84919,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 310,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L310"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L310"
 								}
 							],
 							"signatures": [
@@ -84987,7 +84987,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 88,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L88"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L88"
 								}
 							],
 							"signatures": [
@@ -85085,7 +85085,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 322,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L322"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L322"
 								}
 							],
 							"signatures": [
@@ -85143,7 +85143,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 180,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L180"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L180"
 								}
 							],
 							"signatures": [
@@ -85211,7 +85211,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 348,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L348"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L348"
 								}
 							],
 							"signatures": [
@@ -85247,7 +85247,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 56,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L56"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L56"
 								}
 							],
 							"signatures": [
@@ -85351,7 +85351,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 226,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L226"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L226"
 								}
 							],
 							"signatures": [
@@ -85398,7 +85398,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 75,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L75"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L75"
 								}
 							],
 							"signatures": [
@@ -85466,7 +85466,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 119,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L119"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L119"
 								}
 							],
 							"signatures": [
@@ -85534,7 +85534,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 204,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L204"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L204"
 								}
 							],
 							"signatures": [
@@ -85580,7 +85580,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 195,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L195"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L195"
 								}
 							],
 							"signatures": [
@@ -85626,7 +85626,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 214,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L214"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L214"
 								}
 							],
 							"signatures": [
@@ -85704,7 +85704,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 105,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L105"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L105"
 								}
 							],
 							"signatures": [
@@ -85772,7 +85772,7 @@
 									"fileName": "src/Chunk.ts",
 									"line": 188,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/Chunk.ts#L188"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/Chunk.ts#L188"
 								}
 							],
 							"signatures": [
@@ -85840,7 +85840,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 363,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L363"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L363"
 								}
 							],
 							"signatures": [
@@ -85959,7 +85959,7 @@
 							"fileName": "src/lighting/StandardModel.ts",
 							"line": 261,
 							"character": 13,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L261"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L261"
 						}
 					],
 					"extendedTypes": [
@@ -85997,7 +85997,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 90,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L90"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L90"
 								}
 							],
 							"signatures": [
@@ -86060,7 +86060,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 83,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L83"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L83"
 								}
 							],
 							"type": {
@@ -86100,7 +86100,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 81,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L81"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L81"
 								}
 							],
 							"type": {
@@ -86149,7 +86149,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 85,
 									"character": 10,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L85"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L85"
 								}
 							],
 							"type": {
@@ -86186,7 +86186,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 64,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L64"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L64"
 								}
 							],
 							"type": {
@@ -86214,7 +86214,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 69,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L69"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L69"
 								}
 							],
 							"type": {
@@ -86242,7 +86242,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 67,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L67"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L67"
 								}
 							],
 							"type": {
@@ -86270,7 +86270,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 71,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L71"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L71"
 								}
 							],
 							"type": {
@@ -86298,7 +86298,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 73,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L73"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L73"
 								}
 							],
 							"type": {
@@ -86318,7 +86318,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 145,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L145"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L145"
 								}
 							],
 							"signatures": [
@@ -86386,7 +86386,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 168,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L168"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L168"
 								}
 							],
 							"signatures": [
@@ -86436,7 +86436,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 129,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L129"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L129"
 								}
 							],
 							"signatures": [
@@ -86483,7 +86483,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 157,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L157"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L157"
 								}
 							],
 							"signatures": [
@@ -86552,7 +86552,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 123,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L123"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L123"
 								}
 							],
 							"signatures": [
@@ -86617,7 +86617,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 151,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L151"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L151"
 								}
 							],
 							"signatures": [
@@ -86685,7 +86685,7 @@
 									"fileName": "src/lighting/StandardModel.ts",
 									"line": 136,
 									"character": 2,
-									"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L136"
+									"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L136"
 								}
 							],
 							"signatures": [
@@ -86781,7 +86781,7 @@
 							"fileName": "src/lighting/StandardModel.ts",
 							"line": 62,
 							"character": 6,
-							"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L62"
+							"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L62"
 						}
 					],
 					"implementedTypes": [
@@ -86809,7 +86809,7 @@
 					"fileName": "src/lighting/StandardModel.ts",
 					"line": 2,
 					"character": 0,
-					"url": "https://github.com/plepers/nanogl-pbr/blob/7956ee7/src/lighting/StandardModel.ts#L2"
+					"url": "https://github.com/FlorentinMonteil/nanogl-pbr/blob/d8b9c58/src/lighting/StandardModel.ts#L2"
 				}
 			]
 		}

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -510,7 +510,7 @@ export class Attribute extends BaseParams implements IInputParam {
 
     this.name = name;
     this.size = size;
-    this.token = `v_${this.name}`;
+    this.token = `va${this.name}`;
   }
 
 

--- a/test/input.js
+++ b/test/input.js
@@ -44,9 +44,9 @@ describe( "Input", function(){
 
     //   inputs.compile()
       var codes = inputs.getCode();
-      expect( codes.slotsMap.pv.code ).to.be( 'IN float aInput;\nOUT float v_aInput;\n\n' );
-      expect( codes.slotsMap.v.code  ).to.be( 'v_aInput = aInput;\n\n' );
-      expect( codes.slotsMap.pf.code ).to.be( 'IN float v_aInput;\n\n#define _input(k) v_aInput\n' );
+      expect( codes.slotsMap.pv.code ).to.be( 'IN float aInput;\nOUT float vaaInput;\n\n' );
+      expect( codes.slotsMap.v.code  ).to.be( 'vaaInput = aInput;\n\n' );
+      expect( codes.slotsMap.pf.code ).to.be( 'IN float vaaInput;\n\n#define _input(k) vaaInput\n' );
       expect( codes.slotsMap.f  ).to.be( undefined );
 
     });


### PR DESCRIPTION
Update `v_` to `va` prefix for token name in attribute chunk. 
This prevents the shader compile error for certain custom attribute (exported with a leading `_` in blender for instance) : 
`identifiers containing two consecutive underscores (__) are reserved as possible future keywords`

